### PR TITLE
Handle IPC results using callbacks

### DIFF
--- a/include/ggl/ipc/client.h
+++ b/include/ggl/ipc/client.h
@@ -47,7 +47,7 @@ typedef struct {
 /// `json_handler` or `binary_handler` may be NULL if that payload type is not
 /// expected.
 GglError ggipc_subscribe_to_topic(
-    GglBuffer topic, const GgIpcSubscribeToTopicCallbacks *handlers
+    GglBuffer topic, const GgIpcSubscribeToTopicCallbacks *callbacks
 ) NONNULL(2) ACCESS(read_only, 2);
 
 /// Publish an MQTT message to AWS IoT Core on a topic
@@ -58,13 +58,15 @@ GglError ggipc_publish_to_iot_core(
     GglBuffer topic_name, GglBuffer payload, uint8_t qos, GglArena alloc
 );
 
-typedef void (*GgIpcSubscribeToIotCoreCallback)(
+typedef void GgIpcSubscribeToIotCoreCallback(
     GglBuffer topic, GglBuffer payload
 );
 
 /// Subscribe to MQTT messages from AWS IoT Core on a topic or topic filter
 GglError ggipc_subscribe_to_iot_core(
-    GglBuffer topic_filter, uint8_t qos, GgIpcSubscribeToIotCoreCallback handler
+    GglBuffer topic_filter,
+    uint8_t qos,
+    GgIpcSubscribeToIotCoreCallback *callback
 ) NONNULL(3);
 
 /// Get a configuration value for a component on the core device

--- a/include/ggl/ipc/client_raw.h
+++ b/include/ggl/ipc/client_raw.h
@@ -5,14 +5,9 @@
 #ifndef GGL_IPC_CLIENT_RAW_H
 #define GGL_IPC_CLIENT_RAW_H
 
-#include <ggl/arena.h>
-#include <ggl/attr.h>
 #include <ggl/buffer.h>
 #include <ggl/error.h>
-#include <ggl/ipc/error.h>
 #include <ggl/object.h>
-
-#define GGL_IPC_SVCUID_STR_LEN (16)
 
 /// Maximum number of eventstream streams. Limits subscriptions.
 /// Max subscriptions is this minus 2.
@@ -21,16 +16,21 @@
 #define GGL_IPC_MAX_STREAMS 16
 #endif
 
+typedef GglError GgIpcResultCallback(void *ctx, GglObject result);
+typedef GglError GgIpcErrorCallback(
+    void *ctx, GglBuffer error_code, GglBuffer message
+);
+
 GglError ggipc_call(
     GglBuffer operation,
     GglBuffer service_model_type,
     GglMap params,
-    GglArena *alloc,
-    GglObject *result,
-    GglIpcError *remote_err
-) ACCESS(read_write, 4) ACCESS(write_only, 5) ACCESS(write_only, 6);
+    GgIpcResultCallback *result_callback,
+    GgIpcErrorCallback *error_callback,
+    void *response_ctx
+);
 
-typedef GglError (*GgIpcSubscribeCallback)(
+typedef GglError GgIpcSubscribeCallback(
     void *ctx, GglBuffer service_model_type, GglMap data
 );
 
@@ -38,11 +38,11 @@ GglError ggipc_subscribe(
     GglBuffer operation,
     GglBuffer service_model_type,
     GglMap params,
-    GgIpcSubscribeCallback on_response,
-    void *ctx,
-    GglArena *alloc,
-    GglObject *result,
-    GglIpcError *remote_err
-) NONNULL(4) ACCESS(read_write, 6) ACCESS(write_only, 7) ACCESS(write_only, 8);
+    GgIpcResultCallback *result_callback,
+    GgIpcErrorCallback *error_callback,
+    void *response_callback_ctx,
+    GgIpcSubscribeCallback *sub_callback,
+    void *sub_callback_ctx
+);
 
 #endif

--- a/priv_include/ggl/ipc/error.h
+++ b/priv_include/ggl/ipc/error.h
@@ -5,6 +5,8 @@
 #ifndef GGL_IPC_ERROR_H
 #define GGL_IPC_ERROR_H
 
+// TODO: Move this into Lite Nucleus repo
+
 #include <ggl/attr.h>
 #include <ggl/buffer.h>
 
@@ -35,7 +37,5 @@ void ggl_ipc_err_info(
     GglBuffer *err_str,
     GglBuffer *service_model_type
 ) ACCESS(write_only, 2) ACCESS(write_only, 3);
-
-GglIpcErrorCode get_ipc_err_info(GglBuffer error_code) PURE;
 
 #endif

--- a/src/ipc/client/private_get_system_config.c
+++ b/src/ipc/client/private_get_system_config.c
@@ -7,55 +7,58 @@
 #include <ggl/error.h>
 #include <ggl/ipc/client_priv.h>
 #include <ggl/ipc/client_raw.h>
-#include <ggl/ipc/error.h>
 #include <ggl/log.h>
 #include <ggl/map.h>
 #include <ggl/object.h>
+#include <stddef.h>
 
-GglError ggipc_private_get_system_config(GglBuffer key, GglBuffer *value) {
-    GglArena alloc = ggl_arena_init(*value);
-    GglObject resp = { 0 };
-    GglIpcError remote_error = GGL_IPC_ERROR_DEFAULT;
-    GglError ret = ggipc_call(
-        GGL_STR("aws.greengrass.private#GetSystemConfig"),
-        GGL_STR("aws.greengrass.private#GetSystemConfigRequest"),
-        GGL_MAP(ggl_kv(GGL_STR("key"), ggl_obj_buf(key))),
-        &alloc,
-        &resp,
-        &remote_error
+static GglError error_handler(
+    void *ctx, GglBuffer error_code, GglBuffer message
+) {
+    (void) ctx;
+
+    GGL_LOGE(
+        "Received PrivateGetSystemConfig error %.*s: %.*s.",
+        (int) error_code.len,
+        error_code.data,
+        (int) message.len,
+        message.data
     );
-    if (ret == GGL_ERR_REMOTE) {
-        if (remote_error.error_code != GGL_IPC_ERR_INVALID_ARGUMENTS) {
-            GGL_LOGE(
-                "Invalid arguments: %.*s",
-                (int) remote_error.message.len,
-                remote_error.message.data
-            );
-            return GGL_ERR_INVALID;
-        }
 
-        GGL_LOGE("Server error.");
-        return GGL_ERR_FAILURE;
-    }
+    return GGL_ERR_FAILURE;
+}
 
-    if (ret != GGL_ERR_OK) {
-        return ret;
-    }
+static GglError copy_config_buf(void *ctx, GglObject result) {
+    GglBuffer *resp_buf = ctx;
 
-    if (ggl_obj_type(resp) != GGL_TYPE_BUF) {
+    if (ggl_obj_type(result) != GGL_TYPE_BUF) {
         GGL_LOGE("Config value is not a string.");
         return GGL_ERR_FAILURE;
     }
 
-    *value = ggl_obj_into_buf(resp);
+    if (resp_buf != NULL) {
+        GglBuffer value = ggl_obj_into_buf(result);
 
-    GGL_LOGT(
-        "Read %.*s: %.*s.",
-        (int) key.len,
-        key.data,
-        (int) value->len,
-        value->data
-    );
+        GglArena alloc = ggl_arena_init(*resp_buf);
+        GglError ret = ggl_arena_claim_buf(&value, &alloc);
+        if (ret != GGL_ERR_OK) {
+            GGL_LOGE("Insufficent memory provided for response.");
+            return ret;
+        }
+
+        *resp_buf = value;
+    }
 
     return GGL_ERR_OK;
+}
+
+GglError ggipc_private_get_system_config(GglBuffer key, GglBuffer *value) {
+    return ggipc_call(
+        GGL_STR("aws.greengrass.private#GetSystemConfig"),
+        GGL_STR("aws.greengrass.private#GetSystemConfigRequest"),
+        GGL_MAP(ggl_kv(GGL_STR("key"), ggl_obj_buf(key))),
+        &copy_config_buf,
+        &error_handler,
+        value
+    );
 }

--- a/src/ipc/client/publish_to_topic.c
+++ b/src/ipc/client/publish_to_topic.c
@@ -8,12 +8,29 @@
 #include <ggl/error.h>
 #include <ggl/ipc/client.h>
 #include <ggl/ipc/client_raw.h>
-#include <ggl/ipc/error.h>
 #include <ggl/log.h>
 #include <ggl/map.h>
 #include <ggl/object.h>
 #include <string.h>
-#include <stdint.h>
+
+static GglError error_handler(
+    void *ctx, GglBuffer error_code, GglBuffer message
+) {
+    (void) ctx;
+
+    GGL_LOGE(
+        "Received PublishToTopic error %.*s: %.*s.",
+        (int) error_code.len,
+        error_code.data,
+        (int) message.len,
+        message.data
+    );
+
+    if (ggl_buffer_eq(error_code, GGL_STR("UnauthorizedError"))) {
+        return GGL_ERR_UNSUPPORTED;
+    }
+    return GGL_ERR_FAILURE;
+}
 
 static GglError publish_to_topic_common(
     GglBuffer topic, GglMap publish_message
@@ -23,30 +40,14 @@ static GglError publish_to_topic_common(
         ggl_kv(GGL_STR("publishMessage"), ggl_obj_map(publish_message))
     );
 
-    GglArena error_alloc = ggl_arena_init(GGL_BUF((uint8_t[128]) { 0 }));
-    GglIpcError remote_error = GGL_IPC_ERROR_DEFAULT;
-    GglError ret = ggipc_call(
+    return ggipc_call(
         GGL_STR("aws.greengrass#PublishToTopic"),
         GGL_STR("aws.greengrass#PublishToTopicRequest"),
         args,
-        &error_alloc,
         NULL,
-        &remote_error
+        &error_handler,
+        NULL
     );
-    if (ret == GGL_ERR_REMOTE) {
-        if (remote_error.error_code == GGL_IPC_ERR_UNAUTHORIZED_ERROR) {
-            GGL_LOGE(
-                "Component unauthorized: %.*s",
-                (int) remote_error.message.len,
-                remote_error.message.data
-            );
-            return GGL_ERR_UNSUPPORTED;
-        }
-        GGL_LOGE("Server error.");
-        return GGL_ERR_FAILURE;
-    }
-
-    return ret;
 }
 
 GglError ggipc_publish_to_topic_json(GglBuffer topic, GglMap payload) {

--- a/src/ipc/client/update_config.c
+++ b/src/ipc/client/update_config.c
@@ -16,6 +16,22 @@
 
 struct timespec;
 
+static GglError error_handler(
+    void *ctx, GglBuffer error_code, GglBuffer message
+) {
+    (void) ctx;
+
+    GGL_LOGE(
+        "Received UpdateConfig error %.*s: %.*s.",
+        (int) error_code.len,
+        error_code.data,
+        (int) message.len,
+        message.data
+    );
+
+    return GGL_ERR_FAILURE;
+}
+
 GglError ggipc_update_config(
     GglBufList key_path,
     const struct timespec *timestamp,
@@ -49,18 +65,12 @@ GglError ggipc_update_config(
         ggl_kv(GGL_STR("valueToMerge"), value_to_merge)
     );
 
-    ret = ggipc_call(
+    return ggipc_call(
         GGL_STR("aws.greengrass#UpdateConfiguration"),
         GGL_STR("aws.greengrass#UpdateConfigurationRequest"),
         args,
         NULL,
-        NULL,
+        &error_handler,
         NULL
     );
-    if (ret == GGL_ERR_REMOTE) {
-        GGL_LOGE("Server error.");
-        return GGL_ERR_FAILURE;
-    }
-
-    return ret;
 }

--- a/src/ipc_error.c
+++ b/src/ipc_error.c
@@ -4,7 +4,6 @@
 
 #include <ggl/buffer.h>
 #include <ggl/ipc/error.h>
-#include <ggl/log.h>
 #include <stddef.h>
 
 void ggl_ipc_err_info(
@@ -78,40 +77,4 @@ void ggl_ipc_err_info(
     if (service_model_type != NULL) {
         *service_model_type = service_model_type_val;
     }
-}
-
-GglIpcErrorCode get_ipc_err_info(GglBuffer error_code) {
-    GglIpcErrorCode ret;
-    if (ggl_buffer_eq(GGL_STR("ServiceError"), error_code)) {
-        ret = GGL_IPC_ERR_SERVICE_ERROR;
-    } else if (ggl_buffer_eq(GGL_STR("ResourceNotFoundError"), error_code)) {
-        ret = GGL_IPC_ERR_RESOURCE_NOT_FOUND;
-    } else if (ggl_buffer_eq(GGL_STR("InvalidArgumentsError"), error_code)) {
-        ret = GGL_IPC_ERR_INVALID_ARGUMENTS;
-    } else if (ggl_buffer_eq(GGL_STR("ComponentNotFoundError"), error_code)) {
-        ret = GGL_IPC_ERR_COMPONENT_NOT_FOUND;
-    } else if (ggl_buffer_eq(GGL_STR("UnauthorizedError"), error_code)) {
-        ret = GGL_IPC_ERR_UNAUTHORIZED_ERROR;
-    } else if (ggl_buffer_eq(GGL_STR("ConflictError"), error_code)) {
-        ret = GGL_IPC_ERR_CONFLICT_ERROR;
-    } else if (ggl_buffer_eq(
-                   GGL_STR("FailedUpdateConditionCheckError"), error_code
-               )) {
-        ret = GGL_IPC_ERR_FAILED_UPDATE_CONDITION_CHECK_ERROR;
-    } else if (ggl_buffer_eq(GGL_STR("InvalidTokenError"), error_code)) {
-        ret = GGL_IPC_ERR_INVALID_TOKEN_ERROR;
-    } else if (ggl_buffer_eq(
-                   GGL_STR("InvalidRecipeDirectoryPathError"), error_code
-               )) {
-        ret = GGL_IPC_ERR_INVALID_RECIPE_DIRECTORY_PATH_ERROR;
-    } else if (ggl_buffer_eq(
-                   GGL_STR("InvalidArtifactsDirectoryPathError"), error_code
-               )) {
-        ret = GGL_IPC_ERR_INVALID_ARTIFACTS_DIRECTORY_PATH_ERROR;
-    } else {
-        GGL_LOGW("Unknown error code.");
-        ret = GGL_IPC_ERR_SERVICE_ERROR;
-    }
-
-    return ret;
 }


### PR DESCRIPTION
This prevents forcing an allocation strategy on the caller, and allows calls to use the result without copying to another buffer.

Also reduces stack usage for GetConfig calls.