### PR TITLE
Update ggl_json_encode to use GglWriter

### DIFF
--- a/priv_include/ggl/json_encode.h
+++ b/priv_include/ggl/json_encode.h
@@ -7,13 +7,12 @@
 
 //! JSON encoding
 
-#include <ggl/buffer.h>
 #include <ggl/error.h>
 #include <ggl/io.h>
 #include <ggl/object.h>
 
 /// Serializes a GglObject into a buffer in JSON encoding.
-GglError ggl_json_encode(GglObject obj, GglBuffer *buf);
+GglError ggl_json_encode(GglObject obj, GglWriter writer);
 
 /// Reader from which a JSON-serialized object can be read.
 /// Errors if buffer is not large enough for entire object.

--- a/src/json_encode.c
+++ b/src/json_encode.c
@@ -12,109 +12,110 @@
 #include <ggl/map.h>
 #include <ggl/object.h>
 #include <inttypes.h>
-#include <string.h>
 #include <stdbool.h>
-#include <stdint.h>
 #include <stdio.h>
 
-static GglError json_write(GglObject obj, GglBuffer *buf);
+static GglError json_write(GglObject obj, GglWriter writer);
 
-static GglError buf_write(GglBuffer str, GglBuffer *buf) {
-    if (buf->len < str.len) {
-        GGL_LOGE("Insufficient buffer space to encode json.");
-        return GGL_ERR_NOMEM;
-    }
-
-    memcpy(buf->data, str.data, str.len);
-    *buf = ggl_buffer_substr(*buf, str.len, SIZE_MAX);
-
-    return GGL_ERR_OK;
+static GglError json_write_null(GglWriter writer) {
+    return ggl_writer_call(writer, GGL_STR("null"));
 }
 
-static GglError json_write_null(GglBuffer *buf) {
-    GglError ret = buf_write(GGL_STR("null"), buf);
-    if (ret != GGL_ERR_OK) {
-        return ret;
-    }
-    return GGL_ERR_OK;
+static GglError json_write_bool(bool b, GglWriter writer) {
+    return ggl_writer_call(writer, b ? GGL_STR("true") : GGL_STR("false"));
 }
 
-static GglError json_write_bool(bool b, GglBuffer *buf) {
-    GglError ret = buf_write(b ? GGL_STR("true") : GGL_STR("false"), buf);
-    if (ret != GGL_ERR_OK) {
-        return ret;
-    }
-    return GGL_ERR_OK;
-}
-
-static GglError json_write_i64(int64_t i64, GglBuffer *buf) {
-    int ret = snprintf((char *) buf->data, buf->len, "%" PRId64, i64);
-    if (ret < 0) {
+static GglError json_write_i64(int64_t i64, GglWriter writer) {
+    // (size_t) (  ( CHAR_BITS * sizeof(int64_t) - 1 )  * log10( 2.0 ) ) + 1U
+    char encoded[19];
+    int ret_len = snprintf(encoded, sizeof(encoded), "%" PRId64, i64);
+    if (ret_len < 0) {
         GGL_LOGE("Error encoding json.");
         return GGL_ERR_FAILURE;
     }
-    if ((size_t) ret > buf->len) {
-        GGL_LOGE("Insufficient buffer space to encode json.");
+    if ((size_t) ret_len > sizeof(encoded)) {
+        assert((size_t) ret_len <= sizeof(encoded));
         return GGL_ERR_NOMEM;
     }
-    *buf = ggl_buffer_substr(*buf, (size_t) ret, SIZE_MAX);
-    return GGL_ERR_OK;
+    return ggl_writer_call(
+        writer,
+        (GglBuffer) { .data = (uint8_t *) encoded, .len = (size_t) ret_len }
+    );
 }
 
-static GglError json_write_f64(double f64, GglBuffer *buf) {
-    int ret
-        = snprintf((char *) buf->data, buf->len, "%#.*g", DBL_DECIMAL_DIG, f64);
-    if (ret < 0) {
+static GglError json_write_f64(double f64, GglWriter writer) {
+    char encoded[DBL_DECIMAL_DIG + 4]; // -x.xxxxxxxE-xxxx
+    int ret_len
+        = snprintf(encoded, sizeof(encoded), "%#.*g", DBL_DECIMAL_DIG, f64);
+    if (ret_len < 0) {
         GGL_LOGE("Error encoding json.");
         return GGL_ERR_FAILURE;
     }
-    if ((size_t) ret > buf->len) {
-        GGL_LOGE("Insufficient buffer space to encode json.");
+    if ((size_t) ret_len > sizeof(encoded)) {
+        assert((size_t) ret_len <= sizeof(encoded));
         return GGL_ERR_NOMEM;
     }
-    *buf = ggl_buffer_substr(*buf, (size_t) ret, SIZE_MAX);
-    return GGL_ERR_OK;
+    return ggl_writer_call(
+        writer,
+        (GglBuffer) { .data = (uint8_t *) encoded, .len = (size_t) ret_len }
+    );
 }
 
-static GglError json_write_buf(GglBuffer str, GglBuffer *buf) {
-    GglError ret = buf_write(GGL_STR("\""), buf);
+static GglError json_write_buf_byte(uint8_t byte, GglWriter writer) {
+    GglError ret = GGL_ERR_OK;
+    if ((char) byte == '"') {
+        ret = ggl_writer_call(writer, GGL_STR("\\\""));
+        if (ret != GGL_ERR_OK) {
+            return ret;
+        }
+    } else if ((char) byte == '\\') {
+        ret = ggl_writer_call(writer, GGL_STR("\\\\"));
+        if (ret != GGL_ERR_OK) {
+            return ret;
+        }
+    } else if (byte <= 0x001F) {
+        uint8_t encoded_byte[7];
+        int ret_len = snprintf(
+            (char *) encoded_byte, sizeof(encoded_byte), "\\u00%02X", byte
+        );
+        if (ret_len < 0) {
+            GGL_LOGE("Error encoding json.");
+            return GGL_ERR_FAILURE;
+        }
+        if ((size_t) ret_len > sizeof(encoded_byte)) {
+            assert((size_t) ret_len <= sizeof(encoded_byte));
+            return GGL_ERR_NOMEM;
+        }
+        ret = ggl_writer_call(
+            writer,
+            (GglBuffer) { .data = encoded_byte, .len = (size_t) ret_len }
+        );
+        if (ret != GGL_ERR_OK) {
+            return ret;
+        }
+    } else {
+        ret = ggl_writer_call(writer, (GglBuffer) { .data = &byte, .len = 1 });
+        if (ret != GGL_ERR_OK) {
+            return ret;
+        }
+    }
+    return ret;
+}
+
+static GglError json_write_buf(GglBuffer str, GglWriter writer) {
+    GglError ret = ggl_writer_call(writer, GGL_STR("\""));
     if (ret != GGL_ERR_OK) {
         return ret;
     }
 
     for (size_t i = 0; i < str.len; i++) {
-        uint8_t byte = str.data[i];
-        if ((char) byte == '"') {
-            ret = buf_write(GGL_STR("\\\""), buf);
-            if (ret != GGL_ERR_OK) {
-                return ret;
-            }
-        } else if ((char) byte == '\\') {
-            ret = buf_write(GGL_STR("\\\\"), buf);
-            if (ret != GGL_ERR_OK) {
-                return ret;
-            }
-        } else if (byte <= 0x001F) {
-            int ret_len
-                = snprintf((char *) buf->data, buf->len, "\\u00%02X", byte);
-            if (ret_len < 0) {
-                GGL_LOGE("Error encoding json.");
-                return GGL_ERR_FAILURE;
-            }
-            if ((size_t) ret_len > buf->len) {
-                GGL_LOGE("Insufficient buffer space to encode json.");
-                return GGL_ERR_NOMEM;
-            }
-            *buf = ggl_buffer_substr(*buf, (size_t) ret_len, SIZE_MAX);
-        } else {
-            ret = buf_write((GglBuffer) { .data = &byte, .len = 1 }, buf);
-            if (ret != GGL_ERR_OK) {
-                return ret;
-            }
+        ret = json_write_buf_byte(str.data[i], writer);
+        if (ret != GGL_ERR_OK) {
+            return ret;
         }
     }
 
-    ret = buf_write(GGL_STR("\""), buf);
+    ret = ggl_writer_call(writer, GGL_STR("\""));
     if (ret != GGL_ERR_OK) {
         return ret;
     }
@@ -122,27 +123,27 @@ static GglError json_write_buf(GglBuffer str, GglBuffer *buf) {
 }
 
 // NOLINTNEXTLINE(misc-no-recursion)
-static GglError json_write_list(GglList list, GglBuffer *buf) {
-    GglError ret = buf_write(GGL_STR("["), buf);
+static GglError json_write_list(GglList list, GglWriter writer) {
+    GglError ret = ggl_writer_call(writer, GGL_STR("["));
     if (ret != GGL_ERR_OK) {
         return ret;
     }
 
     for (size_t i = 0; i < list.len; i++) {
         if (i != 0) {
-            ret = buf_write(GGL_STR(","), buf);
+            ret = ggl_writer_call(writer, GGL_STR(","));
             if (ret != GGL_ERR_OK) {
                 return ret;
             }
         }
 
-        ret = json_write(list.items[i], buf);
+        ret = json_write(list.items[i], writer);
         if (ret != GGL_ERR_OK) {
             return ret;
         }
     }
 
-    ret = buf_write(GGL_STR("]"), buf);
+    ret = ggl_writer_call(writer, GGL_STR("]"));
     if (ret != GGL_ERR_OK) {
         return ret;
     }
@@ -150,36 +151,36 @@ static GglError json_write_list(GglList list, GglBuffer *buf) {
 }
 
 // NOLINTNEXTLINE(misc-no-recursion)
-static GglError json_write_map(GglMap map, GglBuffer *buf) {
-    GglError ret = buf_write(GGL_STR("{"), buf);
+static GglError json_write_map(GglMap map, GglWriter writer) {
+    GglError ret = ggl_writer_call(writer, GGL_STR("{"));
     if (ret != GGL_ERR_OK) {
         return ret;
     }
 
     for (size_t i = 0; i < map.len; i++) {
         if (i != 0) {
-            ret = buf_write(GGL_STR(","), buf);
+            ret = ggl_writer_call(writer, GGL_STR(","));
             if (ret != GGL_ERR_OK) {
                 return ret;
             }
         }
-        ret = json_write(ggl_obj_buf(ggl_kv_key(map.pairs[i])), buf);
+        ret = json_write(ggl_obj_buf(ggl_kv_key(map.pairs[i])), writer);
         if (ret != GGL_ERR_OK) {
             return ret;
         }
 
-        ret = buf_write(GGL_STR(":"), buf);
+        ret = ggl_writer_call(writer, GGL_STR(":"));
         if (ret != GGL_ERR_OK) {
             return ret;
         }
 
-        ret = json_write(*ggl_kv_val(&map.pairs[i]), buf);
+        ret = json_write(*ggl_kv_val(&map.pairs[i]), writer);
         if (ret != GGL_ERR_OK) {
             return ret;
         }
     }
 
-    ret = buf_write(GGL_STR("}"), buf);
+    ret = ggl_writer_call(writer, GGL_STR("}"));
     if (ret != GGL_ERR_OK) {
         return ret;
     }
@@ -187,35 +188,29 @@ static GglError json_write_map(GglMap map, GglBuffer *buf) {
 }
 
 // NOLINTNEXTLINE(misc-no-recursion)
-static GglError json_write(GglObject obj, GglBuffer *buf) {
+static GglError json_write(GglObject obj, GglWriter writer) {
     switch (ggl_obj_type(obj)) {
     case GGL_TYPE_NULL:
-        return json_write_null(buf);
+        return json_write_null(writer);
     case GGL_TYPE_BOOLEAN:
-        return json_write_bool(ggl_obj_into_bool(obj), buf);
+        return json_write_bool(ggl_obj_into_bool(obj), writer);
     case GGL_TYPE_I64:
-        return json_write_i64(ggl_obj_into_i64(obj), buf);
+        return json_write_i64(ggl_obj_into_i64(obj), writer);
     case GGL_TYPE_F64:
-        return json_write_f64(ggl_obj_into_f64(obj), buf);
+        return json_write_f64(ggl_obj_into_f64(obj), writer);
     case GGL_TYPE_BUF:
-        return json_write_buf(ggl_obj_into_buf(obj), buf);
+        return json_write_buf(ggl_obj_into_buf(obj), writer);
     case GGL_TYPE_LIST:
-        return json_write_list(ggl_obj_into_list(obj), buf);
+        return json_write_list(ggl_obj_into_list(obj), writer);
     case GGL_TYPE_MAP:
-        return json_write_map(ggl_obj_into_map(obj), buf);
+        return json_write_map(ggl_obj_into_map(obj), writer);
     }
     assert(false);
     return GGL_ERR_FAILURE;
 }
 
-GglError ggl_json_encode(GglObject obj, GglBuffer *buf) {
-    GglBuffer buf_copy = *buf;
-    GglError ret = json_write(obj, &buf_copy);
-    if (ret != GGL_ERR_OK) {
-        return ret;
-    }
-    buf->len = (size_t) (buf_copy.data - buf->data);
-    return GGL_ERR_OK;
+GglError ggl_json_encode(GglObject obj, GglWriter writer) {
+    return json_write(obj, writer);
 }
 
 static GglError obj_read(void *ctx, GglBuffer *buf) {
@@ -227,7 +222,7 @@ static GglError obj_read(void *ctx, GglBuffer *buf) {
         return GGL_ERR_INVALID;
     }
 
-    return ggl_json_encode(*obj, buf);
+    return ggl_json_encode(*obj, ggl_buf_writer(buf));
 }
 
 GglReader ggl_json_reader(GglObject *obj) {


### PR DESCRIPTION
Allows more flexible usage (e.g. writing to a file descriptor)

BREAKING CHANGE!

*Issue #, if available:*

*Description of changes:*
Change ggl_json_encode to take a GglWriter
Modify all helper functions to also use GglWriter

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
