### PR TITLE
Provide memory for base64 encoding payloads

### DIFF
--- a/include/ggl/ipc/client.h
+++ b/include/ggl/ipc/client.h
@@ -40,11 +40,8 @@ GglError ggipc_connect_with_token(GglBuffer socket_path, GglBuffer auth_token);
 GglError ggipc_publish_to_topic_json(GglBuffer topic, GglMap payload);
 
 /// Publish a message to a local topic in binary format
-/// Uses an arena to base64-encode a binary message.
-/// base64 encoding will require 4 bytes for every 3 payload bytes.
-GglError ggipc_publish_to_topic_binary(
-    GglBuffer topic, GglBuffer payload, GglArena alloc
-);
+/// Usage may incur memory overhead over using `ggipc_publish_to_topic_b64`
+GglError ggipc_publish_to_topic_binary(GglBuffer topic, GglBuffer payload);
 
 /// Publish a message to a local topic in binary format
 /// Payload must be already base64 encoded.
@@ -66,10 +63,9 @@ GglError ggipc_subscribe_to_topic(
 ) NONNULL(2) ACCESS(read_only, 2);
 
 /// Publish an MQTT message to AWS IoT Core on a topic
-/// Uses an arena to base64-encode a binary message.
-/// base64 encoding will require 4 bytes for every 3 payload bytes.
+/// Usage may incur memory overhead over using `ggipc_publish_to_iot_core_b64`
 GglError ggipc_publish_to_iot_core(
-    GglBuffer topic_name, GglBuffer payload, uint8_t qos, GglArena alloc
+    GglBuffer topic_name, GglBuffer payload, uint8_t qos
 );
 
 /// Publish an MQTT message to AWS IoT Core on a topic

--- a/samples/iot_core_mqtt/main.c
+++ b/samples/iot_core_mqtt/main.c
@@ -1,13 +1,11 @@
 //! Sample component demonstrating pubsub with AWS IoT Core
 
-#include <ggl/arena.h>
 #include <ggl/buffer.h>
 #include <ggl/error.h>
 #include <ggl/ipc/client.h>
 #include <ggl/sdk.h>
 #include <unistd.h>
 #include <stdbool.h>
-#include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
 
@@ -41,12 +39,7 @@ int main(void) {
     printf("Subscribed to topic.\n");
 
     while (true) {
-        static uint8_t publish_mem[5000];
-        GglArena publish_arena = ggl_arena_init(GGL_BUF(publish_mem));
-
-        ret = ggipc_publish_to_iot_core(
-            GGL_STR("hello"), GGL_STR("world"), 0, publish_arena
-        );
+        ret = ggipc_publish_to_iot_core(GGL_STR("hello"), GGL_STR("world"), 0);
         if (ret != GGL_ERR_OK) {
             fprintf(stderr, "Failed to call publish_to_iot_core.\n");
             exit(1);

--- a/src/ipc/client/b64_encode_mem.c
+++ b/src/ipc/client/b64_encode_mem.c
@@ -1,0 +1,58 @@
+// aws-greengrass-sdk-lite - Lightweight AWS IoT Greengrass SDK
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+#include <ggl/arena.h>
+#include <ggl/base64.h>
+#include <ggl/buffer.h>
+#include <ggl/cleanup.h>
+#include <ggl/error.h>
+#include <ggl/ipc/client.h>
+#include <ggl/ipc/limits.h>
+#include <ggl/log.h>
+#include <inttypes.h>
+#include <pthread.h>
+#include <sys/types.h>
+
+static uint8_t ipc_b64_encode_mem[GGL_IPC_MAX_MSG_LEN] = { 0 };
+static pthread_mutex_t ipc_b64_encode_mtx = PTHREAD_MUTEX_INITIALIZER;
+
+GglError ggipc_publish_to_topic_binary(GglBuffer topic, GglBuffer payload) {
+    GGL_MTX_SCOPE_GUARD(&ipc_b64_encode_mtx);
+    GglArena arena = ggl_arena_init(GGL_BUF(ipc_b64_encode_mem));
+
+    GglBuffer b64_payload;
+    GglError ret = ggl_base64_encode(payload, &arena, &b64_payload);
+    if (ret != GGL_ERR_OK) {
+        GGL_LOGE(
+            "Insufficient memory provided to base64 encode PublishToTopic "
+            "payload (required %zu, provided %" PRIu32 ").",
+            ((payload.len + 2) / 3) * 4,
+            arena.capacity - arena.index
+        );
+        return ret;
+    }
+
+    return ggipc_publish_to_topic_binary_b64(topic, b64_payload);
+}
+
+GglError ggipc_publish_to_iot_core(
+    GglBuffer topic_name, GglBuffer payload, uint8_t qos
+) {
+    GGL_MTX_SCOPE_GUARD(&ipc_b64_encode_mtx);
+    GglArena arena = ggl_arena_init(GGL_BUF(ipc_b64_encode_mem));
+
+    GglBuffer b64_payload;
+    GglError ret = ggl_base64_encode(payload, &arena, &b64_payload);
+    if (ret != GGL_ERR_OK) {
+        GGL_LOGE(
+            "Insufficient memory provided to base64 encode PublishToIoTCore "
+            "payload (required %zu, available %" PRIu32 ").",
+            ((payload.len + 2) / 3) * 4,
+            arena.capacity - arena.index
+        );
+        return ret;
+    }
+
+    return ggipc_publish_to_iot_core_b64(topic_name, b64_payload, qos);
+}

--- a/src/ipc/client/publish_to_iot_core.c
+++ b/src/ipc/client/publish_to_iot_core.c
@@ -2,8 +2,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-#include <ggl/arena.h>
-#include <ggl/base64.h>
 #include <ggl/buffer.h>
 #include <ggl/error.h>
 #include <ggl/ipc/client.h>
@@ -11,8 +9,8 @@
 #include <ggl/log.h>
 #include <ggl/map.h>
 #include <ggl/object.h>
-#include <inttypes.h>
 #include <string.h>
+#include <stdint.h>
 
 static GglError error_handler(
     void *ctx, GglBuffer error_code, GglBuffer message
@@ -51,22 +49,4 @@ GglError ggipc_publish_to_iot_core_b64(
         &error_handler,
         NULL
     );
-}
-
-GglError ggipc_publish_to_iot_core(
-    GglBuffer topic_name, GglBuffer payload, uint8_t qos, GglArena alloc
-) {
-    GglBuffer b64_payload;
-    GglError ret = ggl_base64_encode(payload, &alloc, &b64_payload);
-    if (ret != GGL_ERR_OK) {
-        GGL_LOGE(
-            "Insufficient memory provided to base64 encode "
-            "PublishToIoTCore payload (required %zu, provided %" PRIu32 ").",
-            ((payload.len + 2) / 3) * 4,
-            alloc.capacity - alloc.index
-        );
-        return ret;
-    }
-
-    return ggipc_publish_to_iot_core_b64(topic_name, b64_payload, qos);
 }

--- a/src/ipc/client/publish_to_topic.c
+++ b/src/ipc/client/publish_to_topic.c
@@ -2,8 +2,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-#include <ggl/arena.h>
-#include <ggl/base64.h>
 #include <ggl/buffer.h>
 #include <ggl/error.h>
 #include <ggl/ipc/client.h>
@@ -11,7 +9,6 @@
 #include <ggl/log.h>
 #include <ggl/map.h>
 #include <ggl/object.h>
-#include <inttypes.h>
 #include <string.h>
 
 static GglError error_handler(
@@ -70,22 +67,4 @@ GglError ggipc_publish_to_topic_binary_b64(
         );
 
     return publish_to_topic_common(topic, publish_message);
-}
-
-GglError ggipc_publish_to_topic_binary(
-    GglBuffer topic, GglBuffer payload, GglArena alloc
-) {
-    GglBuffer b64_payload;
-    GglError ret = ggl_base64_encode(payload, &alloc, &b64_payload);
-    if (ret != GGL_ERR_OK) {
-        GGL_LOGE(
-            "Insufficient memory provided to base64 encode PublishToTopic "
-            "payload (required %zu, provided %" PRIu32 ").",
-            ((payload.len + 2) / 3) * 4,
-            alloc.capacity - alloc.index
-        );
-        return ret;
-    }
-
-    return ggipc_publish_to_topic_binary_b64(topic, b64_payload);
 }


### PR DESCRIPTION
This simplifies the PublishTo{Topic,IoTCore} APIs, at the cost of the base64 translation memory not being controlled by customer. That use case has since been better enabled by the `_b64` function variants though.