### PR TITLE
Fix missing semicolon in crc32.c

### DIFF
--- a/src/crc32.c
+++ b/src/crc32.c
@@ -20,7 +20,7 @@
 #if HAS_BUILTIN_CRC
 
 static uint32_t crc_step(uint32_t crc, uint8_t byte) {
-    return __builtin_rev_crc32_data8(crc, byte, 0x04C11DB7L)
+    return __builtin_rev_crc32_data8(crc, byte, 0x04C11DB7L);
 }
 
 #else


### PR DESCRIPTION
Add missing semicolon after return statement in crc_step function.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
