### PR TITLE
Add get_config IPCs to C++ bindings

### DIFF
--- a/cpp/include/ggl/ipc/client.hpp
+++ b/cpp/include/ggl/ipc/client.hpp
@@ -79,7 +79,20 @@ public:
     std::error_code update_component_state(ComponentState state) noexcept;
 
     std::error_code restart_component(std::string_view component_name) noexcept;
+
+    std::error_code get_config(
+        std::span<const Buffer> key_path,
+        std::optional<std::string_view> component_name,
+        std::string &value
+    ) noexcept;
+
+    std::error_code get_config(
+        std::span<const Buffer> key_path,
+        std::optional<std::string_view> component_name,
+        AllocatedObject &value
+    ) noexcept;
 };
+
 }
 
 #endif

--- a/cpp/include/ggl/list.hpp
+++ b/cpp/include/ggl/list.hpp
@@ -67,7 +67,7 @@ public:
     reference at(size_type pos) const {
         if (pos >= size()) {
             GGL_THROW_OR_ABORT(
-                std::out_of_range("ggl::List::at: out of range")
+                ggl::Exception(GGL_ERR_RANGE, "ggl::List::at: out of range")
             );
         }
 

--- a/cpp/include/ggl/map.hpp
+++ b/cpp/include/ggl/map.hpp
@@ -30,21 +30,14 @@ public:
         return *this = KV { kv };
     }
 
-    KV(GglBuffer key, GglObject value) noexcept
-        : GglKV { ggl_kv(key, value) } {
+    KV(Buffer key, const Object &value) noexcept;
+
+    KV(std::string_view key, const Object &value) noexcept
+        : KV { Buffer { key }, value } {
     }
 
-    KV(std::string_view key, GglObject value) noexcept
-        : KV { as_buffer(key), value } {
-    }
-
-    // key must be null-terminated
-    KV(const char *key, GglObject value) noexcept
-        : KV { as_buffer(key), value } {
-    }
-
-    KV(std::span<uint8_t> key, GglObject value) noexcept
-        : KV { as_buffer(key), value } {
+    KV(std::span<uint8_t> key, const Object &value) noexcept
+        : KV { Buffer { key }, value } {
     }
 
     std::string_view key() const noexcept {
@@ -59,11 +52,11 @@ public:
     }
 
     void key(std::string_view str) noexcept {
-        ggl_kv_set_key(this, as_buffer(str));
+        ggl_kv_set_key(this, Buffer { str });
     }
 
     void key(std::span<uint8_t> key) noexcept {
-        ggl_kv_set_key(this, as_buffer(key));
+        ggl_kv_set_key(this, Buffer { key });
     }
 
     void value(GglObject obj) noexcept {

--- a/cpp/include/ggl/object.hpp
+++ b/cpp/include/ggl/object.hpp
@@ -85,42 +85,43 @@ public:
     constexpr Object(const Object &) noexcept = default;
     constexpr Object &operator=(const Object &) noexcept = default;
 
-    explicit Object(std::monostate /*unused*/) noexcept { };
+    Object(std::monostate /*unused*/) noexcept { };
 
-    explicit Object(std::span<uint8_t> value) noexcept
-        : GglObject { ggl_obj_buf(as_buffer(value)) } {
+    explicit Object(bool boolean) noexcept
+        : GglObject { ggl_obj_bool(boolean) } {
     }
 
-    explicit Object(ggl::Buffer value) noexcept
-        : GglObject { ggl_obj_buf(value) } {
+    Object(std::integral auto i64) noexcept
+        : GglObject { ggl_obj_i64(static_cast<int64_t>(i64)) } {
     }
 
-    explicit Object(List value) noexcept
-        : GglObject { ggl_obj_list(value) } {
+    Object(std::floating_point auto f64) noexcept
+        : GglObject { ggl_obj_f64(static_cast<double>(f64)) } {
     }
 
-    explicit Object(Map value) noexcept
-        : GglObject { ggl_obj_map(value) } {
+    Object(ggl::Buffer buffer) noexcept
+        : GglObject { ggl_obj_buf(buffer) } {
     }
 
-    explicit Object(bool value) noexcept
-        : GglObject { ggl_obj_bool(value) } {
+    Object(std::span<uint8_t> buffer) noexcept
+        : Object { Buffer { buffer } } {
     }
 
-    explicit Object(std::integral auto value) noexcept
-        : GglObject { ggl_obj_i64(static_cast<int64_t>(value)) } {
+    Object(std::string_view str) noexcept
+        : Object { Buffer { str } } {
     }
 
-    explicit Object(std::floating_point auto value) noexcept
-        : GglObject { ggl_obj_f64(static_cast<double>(value)) } {
+    template <size_t N>
+    Object(const char (&arr)[N]) noexcept
+        : Object { std::string_view { arr, N } } {
     }
 
-    explicit Object(const char *str) noexcept
-        : Object { as_buffer(str) } {
+    Object(List list) noexcept
+        : GglObject { ggl_obj_list(list) } {
     }
 
-    explicit Object(std::string_view str) noexcept
-        : Object { as_buffer(str) } {
+    Object(Map map) noexcept
+        : GglObject { ggl_obj_map(map) } {
     }
 
     template <class T>

--- a/cpp/include/ggl/types.hpp
+++ b/cpp/include/ggl/types.hpp
@@ -100,6 +100,8 @@ void ggl_kv_set_key(GglKV *kv, GglBuffer key) noexcept;
 GglError ggl_list_type_check(GglList list, GglObjectType type) noexcept;
 
 void *ggl_arena_alloc(GglArena *arena, size_t size, size_t alignment) noexcept;
+
+GglError ggl_obj_mem_usage(GglObject obj, size_t *size) noexcept;
 }
 
 #endif

--- a/cpp/samples/config_ipc/main.cpp
+++ b/cpp/samples/config_ipc/main.cpp
@@ -1,0 +1,56 @@
+#include <ggl/buffer.hpp>
+#include <ggl/ipc/client.hpp>
+#include <ggl/object.hpp>
+#include <array>
+#include <iostream>
+#include <optional>
+#include <system_error>
+#include <thread>
+
+constexpr int publish_count = 10;
+
+int main() {
+    auto &client = ggl::ipc::Client::get();
+
+    auto error = client.connect();
+
+    if (error) {
+        std::cerr << "Failed to connect (" << error << ")\n";
+        return 1;
+    }
+
+    const std::array TOPIC_CONFIG_KEY
+        = { ggl::Buffer { "config_ipc" }, ggl::Buffer { "topic" } };
+
+    error = client.update_config(TOPIC_CONFIG_KEY, "/my/topic");
+
+    if (error) {
+        std::cerr << "Failed to set config value (" << error << ")\n";
+        return 1;
+    }
+
+    std::string topic;
+    error = client.get_config(TOPIC_CONFIG_KEY, std::nullopt, topic);
+    if (error) {
+        std::cerr << "Failed to retrieve config value (" << error << ")\n";
+        return 1;
+    }
+
+    std::cout << "Attempting to publish to local topic: \"" << topic << "\"\n";
+
+    for (int i = 0; i < publish_count; ++i) {
+        error = client.publish_to_topic(
+            topic, ggl::Buffer { "Hello from sample_config_ipc!" }
+        );
+
+        if (error) {
+            std::cerr << "Failed to publish to local topic (" << error << ")\n";
+            return 1;
+        }
+
+        using namespace std::chrono_literals;
+        std::this_thread::sleep_for(1s);
+    }
+
+    return 0;
+}

--- a/cpp/samples/object_manipulation/main.cpp
+++ b/cpp/samples/object_manipulation/main.cpp
@@ -19,14 +19,12 @@ int main() {
     std::array list { ggl::Object { "15" },
                       ggl::Object { 24 },
                       ggl::Object { 4.0 } };
-    std::array pairs {
-        ggl::KV { "key", ggl::Object { false } },
-        ggl::KV { "another key", ggl::Object { "Value" } },
-        ggl::KV { "key3", ggl::Object { "Anything" } },
-        ggl::KV { "key4", ggl::Object { 25 } },
-        ggl::KV { "key5",
-                  ggl::Object { ggl::List { list.data(), list.size() } } }
-    };
+    std::array pairs { ggl::KV { "key", false },
+                       ggl::KV { "another key", "Value" },
+                       ggl::KV { "key3", "Anything" },
+                       ggl::KV { "key4", 25 },
+                       ggl::KV { "key5",
+                                 ggl::List { list.data(), list.size() } } };
     ggl::Map map { pairs.data(), pairs.size() };
     ggl::Buffer buffer { "thing" };
     std::array items { ggl::Object { buffer },

--- a/cpp/src/ipc/client.cpp
+++ b/cpp/src/ipc/client.cpp
@@ -14,7 +14,7 @@ std::error_code Client::connect() noexcept {
     // C++ std::getenv has stronger thread-safety guarantees than C's
     // NOLINTNEXTLINE(concurrency-mt-unsafe)
     char *svcuid = std::getenv("SVCUID");
-    if (svcuid == NULL) {
+    if (svcuid == nullptr) {
         return GGL_ERR_CONFIG;
     }
 
@@ -22,7 +22,7 @@ std::error_code Client::connect() noexcept {
         // NOLINTNEXTLINE(concurrency-mt-unsafe)
         = std::getenv("AWS_GG_NUCLEUS_DOMAIN_SOCKET_FILEPATH_FOR_COMPONENT");
 
-    if (socket_path == NULL) {
+    if (socket_path == nullptr) {
         return GGL_ERR_CONFIG;
     }
 

--- a/cpp/src/ipc/client.cpp
+++ b/cpp/src/ipc/client.cpp
@@ -36,7 +36,7 @@ std::error_code Client::connect(
     std::string_view socket_path, std::string_view auth_token
 ) noexcept {
     return ggipc_connect_with_token(
-        as_buffer(socket_path), as_buffer(auth_token)
+        Buffer { socket_path }, Buffer { auth_token }
     );
 }
 
@@ -49,25 +49,25 @@ std::error_code Client::update_component_state(
 std::error_code Client::publish_to_topic(
     std::string_view topic, Buffer bytes
 ) noexcept {
-    return ggipc_publish_to_topic_binary(as_buffer(topic), bytes);
+    return ggipc_publish_to_topic_binary(Buffer { topic }, bytes);
 }
 
 std::error_code Client::publish_to_topic(
     std::string_view topic, const Map &json
 ) noexcept {
-    return ggipc_publish_to_topic_json(as_buffer(topic), json);
+    return ggipc_publish_to_topic_json(Buffer { topic }, json);
 }
 
 std::error_code Client::publish_to_iot_core(
     std::string_view topic, Buffer bytes, uint8_t qos
 ) noexcept {
-    return ggipc_publish_to_iot_core(as_buffer(topic), bytes, qos);
+    return ggipc_publish_to_iot_core(Buffer { topic }, bytes, qos);
 }
 
 std::error_code Client::restart_component(
     std::string_view component_name
 ) noexcept {
-    return ggipc_restart_component(as_buffer(component_name));
+    return ggipc_restart_component(Buffer { component_name });
 }
 
 // NOLINTEND(readability-convert-member-functions-to-static)

--- a/cpp/src/ipc/get_config.cpp
+++ b/cpp/src/ipc/get_config.cpp
@@ -21,14 +21,14 @@ GglError ggl_arena_claim_obj(GglObject *obj, GglArena *arena) noexcept;
 GglError get_config_str_callback(void *ctx, GglMap result) noexcept {
     std::string &str = *static_cast<std::string *>(ctx);
 
-    std::span<uint8_t> value;
+    std::string_view value;
     std::error_code error = validate_map(result, MapSchema { "value", value });
     if (error) {
         return GGL_ERR_PARSE;
     }
 
     try {
-        str.assign(reinterpret_cast<char *>(value.data()), value.size());
+        str = value;
     } catch (...) {
         return GGL_ERR_NOMEM;
     }
@@ -49,6 +49,11 @@ GglError get_config_obj_callback(void *ctx, GglMap result) noexcept {
     error = ggl_obj_mem_usage(value, &len);
     if (error) {
         return GGL_ERR_INVALID;
+    }
+
+    if (len == 0) {
+        obj = AllocatedObject { value, nullptr };
+        return GGL_ERR_OK;
     }
 
     std::unique_ptr<std::byte[]> alloc { new (std::nothrow) std::byte[len] };

--- a/cpp/src/ipc/get_config.cpp
+++ b/cpp/src/ipc/get_config.cpp
@@ -1,0 +1,142 @@
+#include <ggl/arena.hpp>
+#include <ggl/buffer.hpp>
+#include <ggl/error.hpp>
+#include <ggl/ipc/client.hpp>
+#include <ggl/ipc/client_raw_c_api.hpp>
+#include <ggl/map.hpp>
+#include <ggl/object.hpp>
+#include <ggl/schema.hpp>
+#include <ggl/types.hpp>
+#include <algorithm>
+#include <new>
+#include <system_error>
+
+namespace ggl::ipc::detail {
+
+constexpr size_t ggl_max_object_depth = 15U;
+
+extern "C" {
+GglError ggl_arena_claim_obj(GglObject *obj, GglArena *arena) noexcept;
+
+GglError get_config_str_callback(void *ctx, GglMap result) noexcept {
+    std::string &str = *static_cast<std::string *>(ctx);
+
+    std::span<uint8_t> value;
+    std::error_code error = validate_map(result, MapSchema { "value", value });
+    if (error) {
+        return GGL_ERR_PARSE;
+    }
+
+    try {
+        str.assign(reinterpret_cast<char *>(value.data()), value.size());
+    } catch (...) {
+        return GGL_ERR_NOMEM;
+    }
+
+    return GGL_ERR_OK;
+}
+
+GglError get_config_obj_callback(void *ctx, GglMap result) noexcept {
+    AllocatedObject &obj = *static_cast<AllocatedObject *>(ctx);
+
+    Object value;
+    std::error_code error = validate_map(result, MapSchema { "value", value });
+    if (error) {
+        return GGL_ERR_PARSE;
+    }
+
+    size_t len;
+    error = ggl_obj_mem_usage(value, &len);
+    if (error) {
+        return GGL_ERR_INVALID;
+    }
+
+    std::unique_ptr<std::byte[]> alloc { new (std::nothrow) std::byte[len] };
+    if (alloc == nullptr) {
+        return GGL_ERR_NOMEM;
+    }
+
+    Arena arena { alloc.get(), len };
+    error = ggl_arena_claim_obj(&value, &arena);
+    [[unlikely]] // Object traversal errors won't occur
+    if (error) {
+        return GGL_ERR_NOMEM;
+    }
+    obj = AllocatedObject { value, std::move(alloc) };
+    return GGL_ERR_OK;
+}
+
+GglError get_config_error_callback(
+    [[maybe_unused]] void *ctx,
+    GglBuffer error_code,
+    [[maybe_unused]] GglBuffer message
+) noexcept {
+    if (Buffer { "ResourceNotFoundError" } == error_code) {
+        return GGL_ERR_NOENTRY;
+    }
+    return GGL_ERR_FAILURE;
+}
+}
+
+namespace {
+    GglError get_config_common(
+        std::span<const Buffer> key_path,
+        std::optional<std::string_view> component_name,
+        void *value,
+        GgIpcResultCallback fn
+    ) {
+        if (key_path.size() > ggl_max_object_depth) {
+            return GGL_ERR_NOMEM;
+        }
+
+        std::array<Object, ggl_max_object_depth> key_vec;
+        std::ranges::copy(key_path, key_vec.begin());
+        std::array param_pairs {
+            KV { "keyPath", List { key_vec.data(), key_path.size() } },
+            KV { "componentName", component_name.value_or("") }
+        };
+
+        size_t param_len
+            = param_pairs.size() - (component_name.has_value() ? 0 : 1);
+
+        Map params { param_pairs.data(), param_len };
+
+        return ggipc_call(
+            Buffer { "aws.greengrass#GetConfiguration" },
+            Buffer { "aws.greengrass#GetConfigurationRequest" },
+            params,
+            fn,
+            detail::get_config_error_callback,
+            &value
+        );
+    }
+
+}
+}
+
+namespace ggl::ipc {
+// singleton interface class.
+// NOLINTBEGIN(readability-convert-member-functions-to-static)
+
+std::error_code Client::get_config(
+    std::span<const Buffer> key_path,
+    std::optional<std::string_view> component_name,
+    std::string &value
+) noexcept {
+    return detail::get_config_common(
+        key_path, component_name, &value, detail::get_config_str_callback
+    );
+}
+
+std::error_code Client::get_config(
+    std::span<const Buffer> key_path,
+    std::optional<std::string_view> component_name,
+    AllocatedObject &value
+) noexcept {
+    return detail::get_config_common(
+        key_path, component_name, &value, detail::get_config_obj_callback
+    );
+}
+
+// NOLINTEND(readability-convert-member-functions-to-static)
+}

--- a/cpp/src/map.cpp
+++ b/cpp/src/map.cpp
@@ -8,4 +8,8 @@ Object *KV::value() noexcept {
     return static_cast<Object *>(ggl_kv_val(this));
 }
 
+KV::KV(Buffer key, const Object &value) noexcept
+    : GglKV { ggl_kv(key, value) } {
+}
+
 }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
* Fix bug allowing direct initialization of GglObject private bytes in ggl::KV
   * This change simplifies ggl::Object initialization from other types.
* Add get_config IPC functions to bindings
* Allow std::string_view to be filled in by validate_map MapSchema


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
