### PR TITLE
Cleanup attribute usage

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -84,8 +84,7 @@ if(PROJECT_IS_TOP_LEVEL)
   add_cflags(-pthread -fno-strict-aliasing)
 
   # Following flags are optional
-  add_cflags(-std=gnu11 -fvisibility=hidden -fno-semantic-interposition
-             -fno-common)
+  add_cflags(-std=gnu11 -fno-semantic-interposition -fno-common)
 
   # This stops GCC from generating unstrippable inline DWARF debug info
   add_cflags(-fno-unwind-tables -fno-asynchronous-unwind-tables)

--- a/include/ggl/arena.h
+++ b/include/ggl/arena.h
@@ -42,33 +42,32 @@ static inline GglArena ggl_arena_init(GglBuffer buf) {
     (typeof(type) *) ggl_arena_alloc(arena, (n) * sizeof(type), alignof(type))
 
 /// Allocate `size` bytes with given alignment from an arena.
-VISIBILITY(default)
 void *ggl_arena_alloc(GglArena *arena, size_t size, size_t alignment);
 
 /// Resize ptr's allocation (must be the last allocated ptr).
-VISIBILITY(default) NONNULL(2) ACCESS(read_write, 1) ACCESS(none, 2)
+NONNULL(2) ACCESS(read_write, 1) ACCESS(none, 2)
 GglError ggl_arena_resize_last(
     GglArena arena[static 1], const void *ptr, size_t old_size, size_t size
 );
 
 /// Returns true if arena's mem contains ptr.
-VISIBILITY(default) PURE ACCESS(read_only, 1) ACCESS(none, 2)
+PURE ACCESS(read_only, 1) ACCESS(none, 2)
 bool ggl_arena_owns(const GglArena *arena, const void *ptr);
 
 /// Allocates remaining space into a buffer.
-VISIBILITY(default) ACCESS(read_write, 1)
+ACCESS(read_write, 1)
 GglBuffer ggl_arena_alloc_rest(GglArena *arena);
 
 /// Modifies all of an object's references to point into a given arena
-VISIBILITY(default) ACCESS(read_write, 1) ACCESS(read_write, 2)
+ACCESS(read_write, 1) ACCESS(read_write, 2)
 GglError ggl_arena_claim_obj(GglObject obj[static 1], GglArena *arena);
 
 /// Modifies an buffer to point into a given arena
-VISIBILITY(default) ACCESS(read_write, 1) ACCESS(read_write, 2)
+ACCESS(read_write, 1) ACCESS(read_write, 2)
 GglError ggl_arena_claim_buf(GglBuffer buf[static 1], GglArena *arena);
 
 /// Modifies only the buffers of an object to point into a given arena
-VISIBILITY(default) ACCESS(read_write, 1) ACCESS(read_write, 2)
+ACCESS(read_write, 1) ACCESS(read_write, 2)
 GglError ggl_arena_claim_obj_bufs(GglObject obj[static 1], GglArena *arena);
 
 #endif

--- a/include/ggl/arena.h
+++ b/include/ggl/arena.h
@@ -42,33 +42,33 @@ static inline GglArena ggl_arena_init(GglBuffer buf) {
     (typeof(type) *) ggl_arena_alloc(arena, (n) * sizeof(type), alignof(type))
 
 /// Allocate `size` bytes with given alignment from an arena.
-GGL_EXPORT
+VISIBILITY(default)
 void *ggl_arena_alloc(GglArena *arena, size_t size, size_t alignment);
 
 /// Resize ptr's allocation (must be the last allocated ptr).
-GGL_EXPORT NONNULL(2) ACCESS(read_write, 1) ACCESS(none, 2)
+VISIBILITY(default) NONNULL(2) ACCESS(read_write, 1) ACCESS(none, 2)
 GglError ggl_arena_resize_last(
     GglArena arena[static 1], const void *ptr, size_t old_size, size_t size
 );
 
 /// Returns true if arena's mem contains ptr.
-GGL_EXPORT PURE ACCESS(read_only, 1) ACCESS(none, 2)
+VISIBILITY(default) PURE ACCESS(read_only, 1) ACCESS(none, 2)
 bool ggl_arena_owns(const GglArena *arena, const void *ptr);
 
 /// Allocates remaining space into a buffer.
-GGL_EXPORT ACCESS(read_write, 1)
+VISIBILITY(default) ACCESS(read_write, 1)
 GglBuffer ggl_arena_alloc_rest(GglArena *arena);
 
 /// Modifies all of an object's references to point into a given arena
-GGL_EXPORT ACCESS(read_write, 1) ACCESS(read_write, 2)
+VISIBILITY(default) ACCESS(read_write, 1) ACCESS(read_write, 2)
 GglError ggl_arena_claim_obj(GglObject obj[static 1], GglArena *arena);
 
 /// Modifies an buffer to point into a given arena
-GGL_EXPORT ACCESS(read_write, 1) ACCESS(read_write, 2)
+VISIBILITY(default) ACCESS(read_write, 1) ACCESS(read_write, 2)
 GglError ggl_arena_claim_buf(GglBuffer buf[static 1], GglArena *arena);
 
 /// Modifies only the buffers of an object to point into a given arena
-GGL_EXPORT ACCESS(read_write, 1) ACCESS(read_write, 2)
+VISIBILITY(default) ACCESS(read_write, 1) ACCESS(read_write, 2)
 GglError ggl_arena_claim_obj_bufs(GglObject obj[static 1], GglArena *arena);
 
 #endif

--- a/include/ggl/arena.h
+++ b/include/ggl/arena.h
@@ -42,7 +42,7 @@ static inline GglArena ggl_arena_init(GglBuffer buf) {
     (typeof(type) *) ggl_arena_alloc(arena, (n) * sizeof(type), alignof(type))
 
 /// Allocate `size` bytes with given alignment from an arena.
-GGL_EXPORT ALLOC_ALIGN(3) ACCESS(read_write, 1)
+GGL_EXPORT
 void *ggl_arena_alloc(GglArena *arena, size_t size, size_t alignment);
 
 /// Resize ptr's allocation (must be the last allocated ptr).

--- a/include/ggl/attr.h
+++ b/include/ggl/attr.h
@@ -25,12 +25,6 @@
 #define VISIBILITY(v)
 #endif
 
-#ifdef GGL_SDK_EXPORT_API
-#define GGL_EXPORT VISIBILITY(default)
-#else
-#define GGL_EXPORT VISIBILITY(hidden)
-#endif
-
 #ifdef __has_attribute
 #if __has_attribute(format)
 #define FORMAT(...) __attribute__((format(__VA_ARGS__)))

--- a/include/ggl/attr.h
+++ b/include/ggl/attr.h
@@ -82,26 +82,6 @@
 #endif
 
 #ifdef __has_attribute
-#if __has_attribute(alloc_size)
-#define ALLOC_SIZE(...) __attribute__((alloc_size(__VA_ARGS__)))
-#endif
-#endif
-
-#ifndef ALLOC_SIZE
-#define ALLOC_SIZE(...)
-#endif
-
-#ifdef __has_attribute
-#if __has_attribute(alloc_align)
-#define ALLOC_ALIGN(pos) __attribute__((alloc_align(pos)))
-#endif
-#endif
-
-#ifndef ALLOC_ALIGN
-#define ALLOC_ALIGN(pos)
-#endif
-
-#ifdef __has_attribute
 #if __has_attribute(nonnull)
 #define NONNULL(...) __attribute__((nonnull(__VA_ARGS__)))
 #endif

--- a/include/ggl/base64.h
+++ b/include/ggl/base64.h
@@ -15,15 +15,15 @@
 
 /// Convert a base64 buffer to its decoded data.
 /// Target must be large enough to hold decoded value.
-GGL_EXPORT ACCESS(read_write, 2)
+VISIBILITY(default) ACCESS(read_write, 2)
 bool ggl_base64_decode(GglBuffer base64, GglBuffer target[static 1]);
 
 /// Convert a base64 buffer to its decoded data in place.
-GGL_EXPORT ACCESS(read_write, 1)
+VISIBILITY(default) ACCESS(read_write, 1)
 bool ggl_base64_decode_in_place(GglBuffer target[static 1]);
 
 /// Encode a buffer into base64.
-GGL_EXPORT ACCESS(read_write, 2) ACCESS(write_only, 3)
+VISIBILITY(default) ACCESS(read_write, 2) ACCESS(write_only, 3)
 GglError ggl_base64_encode(
     GglBuffer buf, GglArena *alloc, GglBuffer result[static 1]
 );

--- a/include/ggl/base64.h
+++ b/include/ggl/base64.h
@@ -15,15 +15,15 @@
 
 /// Convert a base64 buffer to its decoded data.
 /// Target must be large enough to hold decoded value.
-VISIBILITY(default) ACCESS(read_write, 2)
+ACCESS(read_write, 2)
 bool ggl_base64_decode(GglBuffer base64, GglBuffer target[static 1]);
 
 /// Convert a base64 buffer to its decoded data in place.
-VISIBILITY(default) ACCESS(read_write, 1)
+ACCESS(read_write, 1)
 bool ggl_base64_decode_in_place(GglBuffer target[static 1]);
 
 /// Encode a buffer into base64.
-VISIBILITY(default) ACCESS(read_write, 2) ACCESS(write_only, 3)
+ACCESS(read_write, 2) ACCESS(write_only, 3)
 GglError ggl_base64_encode(
     GglBuffer buf, GglArena *alloc, GglBuffer result[static 1]
 );

--- a/include/ggl/buffer.h
+++ b/include/ggl/buffer.h
@@ -69,38 +69,38 @@ bool cbmc_buffer_restrict(GglBuffer *buf) {
 #endif
 
 /// Convert null-terminated string to buffer
-GGL_EXPORT PURE NULL_TERMINATED_STRING_ARG(1)
+VISIBILITY(default) PURE NULL_TERMINATED_STRING_ARG(1)
 GglBuffer ggl_buffer_from_null_term(char str[static 1]);
 
 /// Returns whether two buffers have identical content.
-GGL_EXPORT PURE
+VISIBILITY(default) PURE
 bool ggl_buffer_eq(GglBuffer buf1, GglBuffer buf2);
 
 /// Returns whether the buffer has the given prefix.
-GGL_EXPORT PURE
+VISIBILITY(default) PURE
 bool ggl_buffer_has_prefix(GglBuffer buf, GglBuffer prefix);
 
 /// Removes a prefix. Returns whether the prefix was removed.
-GGL_EXPORT ACCESS(read_write, 1)
+VISIBILITY(default) ACCESS(read_write, 1)
 bool ggl_buffer_remove_prefix(GglBuffer buf[static 1], GglBuffer prefix);
 
 /// Returns whether the buffer has the given suffix.
-GGL_EXPORT PURE
+VISIBILITY(default) PURE
 bool ggl_buffer_has_suffix(GglBuffer buf, GglBuffer suffix);
 
 /// Removes a suffix. Returns whether the suffix was removed.
-GGL_EXPORT ACCESS(read_write, 1)
+VISIBILITY(default) ACCESS(read_write, 1)
 bool ggl_buffer_remove_suffix(GglBuffer buf[static 1], GglBuffer suffix);
 
 /// Returns whether the buffer contains the given substring.
 /// Outputs start index if non-null.
-GGL_EXPORT ACCESS(write_only, 3) REPRODUCIBLE
+VISIBILITY(default) ACCESS(write_only, 3) REPRODUCIBLE
 bool ggl_buffer_contains(GglBuffer buf, GglBuffer substring, size_t *start);
 
 /// Returns substring of buffer from start to end.
 /// The result is the overlap between the start to end range and the input
 /// bounds.
-GGL_EXPORT CONST
+VISIBILITY(default) CONST
 GglBuffer ggl_buffer_substr(GglBuffer buf, size_t start, size_t end)
     CBMC_CONTRACT(
         requires(cbmc_buffer_restrict(&buf)),
@@ -125,7 +125,7 @@ GglBuffer ggl_buffer_substr(GglBuffer buf, size_t start, size_t end)
     );
 
 /// Parse an integer from a string
-GGL_EXPORT ACCESS(write_only, 2)
+VISIBILITY(default) ACCESS(write_only, 2)
 GglError ggl_str_to_int64(GglBuffer str, int64_t value[static 1]) CBMC_CONTRACT(
     requires(cbmc_buffer_restrict(&str)),
     requires(cbmc_restrict(value)),

--- a/include/ggl/buffer.h
+++ b/include/ggl/buffer.h
@@ -69,38 +69,38 @@ bool cbmc_buffer_restrict(GglBuffer *buf) {
 #endif
 
 /// Convert null-terminated string to buffer
-VISIBILITY(default) PURE NULL_TERMINATED_STRING_ARG(1)
+PURE NULL_TERMINATED_STRING_ARG(1)
 GglBuffer ggl_buffer_from_null_term(char str[static 1]);
 
 /// Returns whether two buffers have identical content.
-VISIBILITY(default) PURE
+PURE
 bool ggl_buffer_eq(GglBuffer buf1, GglBuffer buf2);
 
 /// Returns whether the buffer has the given prefix.
-VISIBILITY(default) PURE
+PURE
 bool ggl_buffer_has_prefix(GglBuffer buf, GglBuffer prefix);
 
 /// Removes a prefix. Returns whether the prefix was removed.
-VISIBILITY(default) ACCESS(read_write, 1)
+ACCESS(read_write, 1)
 bool ggl_buffer_remove_prefix(GglBuffer buf[static 1], GglBuffer prefix);
 
 /// Returns whether the buffer has the given suffix.
-VISIBILITY(default) PURE
+PURE
 bool ggl_buffer_has_suffix(GglBuffer buf, GglBuffer suffix);
 
 /// Removes a suffix. Returns whether the suffix was removed.
-VISIBILITY(default) ACCESS(read_write, 1)
+ACCESS(read_write, 1)
 bool ggl_buffer_remove_suffix(GglBuffer buf[static 1], GglBuffer suffix);
 
 /// Returns whether the buffer contains the given substring.
 /// Outputs start index if non-null.
-VISIBILITY(default) ACCESS(write_only, 3) REPRODUCIBLE
+ACCESS(write_only, 3) REPRODUCIBLE
 bool ggl_buffer_contains(GglBuffer buf, GglBuffer substring, size_t *start);
 
 /// Returns substring of buffer from start to end.
 /// The result is the overlap between the start to end range and the input
 /// bounds.
-VISIBILITY(default) CONST
+CONST
 GglBuffer ggl_buffer_substr(GglBuffer buf, size_t start, size_t end)
     CBMC_CONTRACT(
         requires(cbmc_buffer_restrict(&buf)),
@@ -125,7 +125,7 @@ GglBuffer ggl_buffer_substr(GglBuffer buf, size_t start, size_t end)
     );
 
 /// Parse an integer from a string
-VISIBILITY(default) ACCESS(write_only, 2)
+ACCESS(write_only, 2)
 GglError ggl_str_to_int64(GglBuffer str, int64_t value[static 1]) CBMC_CONTRACT(
     requires(cbmc_buffer_restrict(&str)),
     requires(cbmc_restrict(value)),

--- a/include/ggl/error.h
+++ b/include/ggl/error.h
@@ -48,7 +48,7 @@ typedef enum NODISCARD GglError {
     GGL_ERR_TIMEOUT,
 } GglError;
 
-VISIBILITY(default) CONST
+CONST
 const char *ggl_strerror(GglError err) CBMC_CONTRACT(
     requires(cbmc_enum_valid(err)), ensures(cbmc_restrict(cbmc_return))
 );

--- a/include/ggl/error.h
+++ b/include/ggl/error.h
@@ -48,7 +48,7 @@ typedef enum NODISCARD GglError {
     GGL_ERR_TIMEOUT,
 } GglError;
 
-GGL_EXPORT CONST
+VISIBILITY(default) CONST
 const char *ggl_strerror(GglError err) CBMC_CONTRACT(
     requires(cbmc_enum_valid(err)), ensures(cbmc_restrict(cbmc_return))
 );

--- a/include/ggl/ipc/client.h
+++ b/include/ggl/ipc/client.h
@@ -29,27 +29,27 @@ struct timespec;
 
 /// Connect to the Greengrass Nucleus from a component.
 /// Not thread-safe due to use of getenv.
-GGL_EXPORT
+VISIBILITY(default)
 GglError ggipc_connect(void);
 
 /// Connect to a GG-IPC socket with a given SVCUID token.
-GGL_EXPORT
+VISIBILITY(default)
 GglError ggipc_connect_with_token(GglBuffer socket_path, GglBuffer auth_token);
 
 // IPC calls
 
 /// Publish a message to a local topic in JSON format
-GGL_EXPORT
+VISIBILITY(default)
 GglError ggipc_publish_to_topic_json(GglBuffer topic, GglMap payload);
 
 /// Publish a message to a local topic in binary format
 /// Usage may incur memory overhead over using `ggipc_publish_to_topic_b64`
-GGL_EXPORT
+VISIBILITY(default)
 GglError ggipc_publish_to_topic_binary(GglBuffer topic, GglBuffer payload);
 
 /// Publish a message to a local topic in binary format
 /// Payload must be already base64 encoded.
-GGL_EXPORT
+VISIBILITY(default)
 GglError ggipc_publish_to_topic_binary_b64(
     GglBuffer topic, GglBuffer b64_payload
 );
@@ -63,21 +63,21 @@ typedef struct {
 /// `handlers` must have static lifetime.
 /// `json_handler` or `binary_handler` may be NULL if that payload type is not
 /// expected.
-GGL_EXPORT ACCESS(read_only, 2)
+VISIBILITY(default) ACCESS(read_only, 2)
 GglError ggipc_subscribe_to_topic(
     GglBuffer topic, const GgIpcSubscribeToTopicCallbacks callbacks[static 1]
 );
 
 /// Publish an MQTT message to AWS IoT Core on a topic
 /// Usage may incur memory overhead over using `ggipc_publish_to_iot_core_b64`
-GGL_EXPORT
+VISIBILITY(default)
 GglError ggipc_publish_to_iot_core(
     GglBuffer topic_name, GglBuffer payload, uint8_t qos
 );
 
 /// Publish an MQTT message to AWS IoT Core on a topic
 /// Payload must be already base64 encoded.
-GGL_EXPORT
+VISIBILITY(default)
 GglError ggipc_publish_to_iot_core_b64(
     GglBuffer topic_name, GglBuffer b64_payload, uint8_t qos
 );
@@ -87,7 +87,7 @@ typedef void GgIpcSubscribeToIotCoreCallback(
 );
 
 /// Subscribe to MQTT messages from AWS IoT Core on a topic or topic filter
-GGL_EXPORT NONNULL(3)
+VISIBILITY(default) NONNULL(3)
 GglError ggipc_subscribe_to_iot_core(
     GglBuffer topic_filter,
     uint8_t qos,
@@ -95,7 +95,7 @@ GglError ggipc_subscribe_to_iot_core(
 );
 
 /// Get a configuration value for a component on the core device
-GGL_EXPORT ACCESS(read_only, 2) ACCESS(read_write, 3) ACCESS(write_only, 4)
+VISIBILITY(default) ACCESS(read_only, 2) ACCESS(read_write, 3) ACCESS(write_only, 4)
 GglError ggipc_get_config(
     GglBufList key_path,
     const GglBuffer *component_name,
@@ -107,13 +107,13 @@ GglError ggipc_get_config(
 /// `value` must point to a buffer large enough to hold the result, and will be
 /// updated to the result string.
 /// Alternative API to ggipc_get_config for string type values.
-GGL_EXPORT ACCESS(read_only, 2) ACCESS(read_write, 3)
+VISIBILITY(default) ACCESS(read_only, 2) ACCESS(read_write, 3)
 GglError ggipc_get_config_str(
     GglBufList key_path, const GglBuffer *component_name, GglBuffer *value
 );
 
 /// Update a configuration value for this component on the core device
-GGL_EXPORT ACCESS(read_only, 2)
+VISIBILITY(default) ACCESS(read_only, 2)
 GglError ggipc_update_config(
     GglBufList key_path,
     const struct timespec *timestamp,
@@ -127,11 +127,11 @@ typedef enum ENUM_EXTENSIBILITY(closed) {
 } GglComponentState;
 
 /// Update the state of this component
-GGL_EXPORT
+VISIBILITY(default)
 GglError ggipc_update_state(GglComponentState state);
 
 /// Restart a component on the core device
-GGL_EXPORT
+VISIBILITY(default)
 GglError ggipc_restart_component(GglBuffer component_name);
 
 #endif

--- a/include/ggl/ipc/client.h
+++ b/include/ggl/ipc/client.h
@@ -29,27 +29,22 @@ struct timespec;
 
 /// Connect to the Greengrass Nucleus from a component.
 /// Not thread-safe due to use of getenv.
-VISIBILITY(default)
 GglError ggipc_connect(void);
 
 /// Connect to a GG-IPC socket with a given SVCUID token.
-VISIBILITY(default)
 GglError ggipc_connect_with_token(GglBuffer socket_path, GglBuffer auth_token);
 
 // IPC calls
 
 /// Publish a message to a local topic in JSON format
-VISIBILITY(default)
 GglError ggipc_publish_to_topic_json(GglBuffer topic, GglMap payload);
 
 /// Publish a message to a local topic in binary format
 /// Usage may incur memory overhead over using `ggipc_publish_to_topic_b64`
-VISIBILITY(default)
 GglError ggipc_publish_to_topic_binary(GglBuffer topic, GglBuffer payload);
 
 /// Publish a message to a local topic in binary format
 /// Payload must be already base64 encoded.
-VISIBILITY(default)
 GglError ggipc_publish_to_topic_binary_b64(
     GglBuffer topic, GglBuffer b64_payload
 );
@@ -63,21 +58,19 @@ typedef struct {
 /// `handlers` must have static lifetime.
 /// `json_handler` or `binary_handler` may be NULL if that payload type is not
 /// expected.
-VISIBILITY(default) ACCESS(read_only, 2)
+ACCESS(read_only, 2)
 GglError ggipc_subscribe_to_topic(
     GglBuffer topic, const GgIpcSubscribeToTopicCallbacks callbacks[static 1]
 );
 
 /// Publish an MQTT message to AWS IoT Core on a topic
 /// Usage may incur memory overhead over using `ggipc_publish_to_iot_core_b64`
-VISIBILITY(default)
 GglError ggipc_publish_to_iot_core(
     GglBuffer topic_name, GglBuffer payload, uint8_t qos
 );
 
 /// Publish an MQTT message to AWS IoT Core on a topic
 /// Payload must be already base64 encoded.
-VISIBILITY(default)
 GglError ggipc_publish_to_iot_core_b64(
     GglBuffer topic_name, GglBuffer b64_payload, uint8_t qos
 );
@@ -87,7 +80,7 @@ typedef void GgIpcSubscribeToIotCoreCallback(
 );
 
 /// Subscribe to MQTT messages from AWS IoT Core on a topic or topic filter
-VISIBILITY(default) NONNULL(3)
+NONNULL(3)
 GglError ggipc_subscribe_to_iot_core(
     GglBuffer topic_filter,
     uint8_t qos,
@@ -95,7 +88,7 @@ GglError ggipc_subscribe_to_iot_core(
 );
 
 /// Get a configuration value for a component on the core device
-VISIBILITY(default) ACCESS(read_only, 2) ACCESS(read_write, 3) ACCESS(write_only, 4)
+ACCESS(read_only, 2) ACCESS(read_write, 3) ACCESS(write_only, 4)
 GglError ggipc_get_config(
     GglBufList key_path,
     const GglBuffer *component_name,
@@ -107,13 +100,13 @@ GglError ggipc_get_config(
 /// `value` must point to a buffer large enough to hold the result, and will be
 /// updated to the result string.
 /// Alternative API to ggipc_get_config for string type values.
-VISIBILITY(default) ACCESS(read_only, 2) ACCESS(read_write, 3)
+ACCESS(read_only, 2) ACCESS(read_write, 3)
 GglError ggipc_get_config_str(
     GglBufList key_path, const GglBuffer *component_name, GglBuffer *value
 );
 
 /// Update a configuration value for this component on the core device
-VISIBILITY(default) ACCESS(read_only, 2)
+ACCESS(read_only, 2)
 GglError ggipc_update_config(
     GglBufList key_path,
     const struct timespec *timestamp,
@@ -127,11 +120,9 @@ typedef enum ENUM_EXTENSIBILITY(closed) {
 } GglComponentState;
 
 /// Update the state of this component
-VISIBILITY(default)
 GglError ggipc_update_state(GglComponentState state);
 
 /// Restart a component on the core device
-VISIBILITY(default)
 GglError ggipc_restart_component(GglBuffer component_name);
 
 #endif

--- a/include/ggl/ipc/client_raw.h
+++ b/include/ggl/ipc/client_raw.h
@@ -5,7 +5,6 @@
 #ifndef GGL_IPC_CLIENT_RAW_H
 #define GGL_IPC_CLIENT_RAW_H
 
-#include <ggl/attr.h>
 #include <ggl/buffer.h>
 #include <ggl/error.h>
 #include <ggl/object.h>
@@ -15,7 +14,6 @@ typedef GglError GgIpcErrorCallback(
     void *ctx, GglBuffer error_code, GglBuffer message
 );
 
-VISIBILITY(default)
 GglError ggipc_call(
     GglBuffer operation,
     GglBuffer service_model_type,
@@ -29,7 +27,6 @@ typedef GglError GgIpcSubscribeCallback(
     void *ctx, GglBuffer service_model_type, GglMap data
 );
 
-VISIBILITY(default)
 GglError ggipc_subscribe(
     GglBuffer operation,
     GglBuffer service_model_type,

--- a/include/ggl/ipc/client_raw.h
+++ b/include/ggl/ipc/client_raw.h
@@ -15,7 +15,7 @@ typedef GglError GgIpcErrorCallback(
     void *ctx, GglBuffer error_code, GglBuffer message
 );
 
-GGL_EXPORT
+VISIBILITY(default)
 GglError ggipc_call(
     GglBuffer operation,
     GglBuffer service_model_type,
@@ -29,7 +29,7 @@ typedef GglError GgIpcSubscribeCallback(
     void *ctx, GglBuffer service_model_type, GglMap data
 );
 
-GGL_EXPORT
+VISIBILITY(default)
 GglError ggipc_subscribe(
     GglBuffer operation,
     GglBuffer service_model_type,

--- a/include/ggl/list.h
+++ b/include/ggl/list.h
@@ -18,7 +18,7 @@
          name = &name[1])
 // NOLINTEND(bugprone-macro-parentheses)
 
-GGL_EXPORT PURE
+VISIBILITY(default) PURE
 GglError ggl_list_type_check(GglList list, GglObjectType type);
 
 #endif

--- a/include/ggl/list.h
+++ b/include/ggl/list.h
@@ -18,7 +18,7 @@
          name = &name[1])
 // NOLINTEND(bugprone-macro-parentheses)
 
-VISIBILITY(default) PURE
+PURE
 GglError ggl_list_type_check(GglList list, GglObjectType type);
 
 #endif

--- a/include/ggl/map.h
+++ b/include/ggl/map.h
@@ -26,29 +26,29 @@
 /// Get the value corresponding with a key.
 /// Returns whether the key was found in the map.
 /// If `result` is not NULL it is set to the found value or NULL.
-VISIBILITY(default) ACCESS(write_only, 3)
+ACCESS(write_only, 3)
 bool ggl_map_get(GglMap map, GglBuffer key, GglObject **result);
 
 /// Get the value from a nested map corresponding with a key path.
 /// Returns whether the key was found in the map.
 /// If `result` is not NULL it is set to the found value or NULL.
-VISIBILITY(default) ACCESS(write_only, 3)
+ACCESS(write_only, 3)
 bool ggl_map_get_path(GglMap map, GglBufList path, GglObject **result);
 
 /// Construct a GglKV
-VISIBILITY(default) CONST
+CONST
 GglKV ggl_kv(GglBuffer key, GglObject val);
 
 /// Get a GglKV's key
-VISIBILITY(default) CONST
+CONST
 GglBuffer ggl_kv_key(GglKV kv);
 
 /// Set a GglKV's key
-VISIBILITY(default) ACCESS(write_only, 1)
+ACCESS(write_only, 1)
 void ggl_kv_set_key(GglKV *kv, GglBuffer key);
 
 /// Get a GglKV's value
-VISIBILITY(default) CONST ACCESS(none, 1)
+CONST ACCESS(none, 1)
 GglObject *ggl_kv_val(GglKV *kv);
 
 typedef struct {
@@ -70,7 +70,6 @@ typedef struct {
             / (sizeof(GglMapSchemaEntry)) \
     }
 
-VISIBILITY(default)
 GglError ggl_map_validate(GglMap map, GglMapSchema schema);
 
 #endif

--- a/include/ggl/map.h
+++ b/include/ggl/map.h
@@ -26,29 +26,29 @@
 /// Get the value corresponding with a key.
 /// Returns whether the key was found in the map.
 /// If `result` is not NULL it is set to the found value or NULL.
-GGL_EXPORT ACCESS(write_only, 3)
+VISIBILITY(default) ACCESS(write_only, 3)
 bool ggl_map_get(GglMap map, GglBuffer key, GglObject **result);
 
 /// Get the value from a nested map corresponding with a key path.
 /// Returns whether the key was found in the map.
 /// If `result` is not NULL it is set to the found value or NULL.
-GGL_EXPORT ACCESS(write_only, 3)
+VISIBILITY(default) ACCESS(write_only, 3)
 bool ggl_map_get_path(GglMap map, GglBufList path, GglObject **result);
 
 /// Construct a GglKV
-GGL_EXPORT CONST
+VISIBILITY(default) CONST
 GglKV ggl_kv(GglBuffer key, GglObject val);
 
 /// Get a GglKV's key
-GGL_EXPORT CONST
+VISIBILITY(default) CONST
 GglBuffer ggl_kv_key(GglKV kv);
 
 /// Set a GglKV's key
-GGL_EXPORT ACCESS(write_only, 1)
+VISIBILITY(default) ACCESS(write_only, 1)
 void ggl_kv_set_key(GglKV *kv, GglBuffer key);
 
 /// Get a GglKV's value
-GGL_EXPORT CONST ACCESS(none, 1)
+VISIBILITY(default) CONST ACCESS(none, 1)
 GglObject *ggl_kv_val(GglKV *kv);
 
 typedef struct {
@@ -70,7 +70,7 @@ typedef struct {
             / (sizeof(GglMapSchemaEntry)) \
     }
 
-GGL_EXPORT
+VISIBILITY(default)
 GglError ggl_map_validate(GglMap map, GglMapSchema schema);
 
 #endif

--- a/include/ggl/object.h
+++ b/include/ggl/object.h
@@ -75,63 +75,63 @@ typedef struct {
     }
 
 /// Get type of an GglObject
-GGL_EXPORT CONST
+VISIBILITY(default) CONST
 GglObjectType ggl_obj_type(GglObject obj);
 
 #define GGL_OBJ_NULL (GglObject) { 0 }
 
 /// Create bool object.
-GGL_EXPORT CONST
+VISIBILITY(default) CONST
 GglObject ggl_obj_bool(bool value);
 
 /// Get the bool represented by an object.
 /// The GglObject must be of type GGL_TYPE_BOOLEAN.
-GGL_EXPORT CONST
+VISIBILITY(default) CONST
 bool ggl_obj_into_bool(GglObject boolean);
 
 /// Create signed integer object.
-GGL_EXPORT CONST
+VISIBILITY(default) CONST
 GglObject ggl_obj_i64(int64_t value);
 
 /// Get the i64 represented by an object.
 /// The GglObject must be of type GGL_TYPE_I64.
-GGL_EXPORT CONST
+VISIBILITY(default) CONST
 int64_t ggl_obj_into_i64(GglObject i64);
 
 /// Create floating point object.
-GGL_EXPORT CONST
+VISIBILITY(default) CONST
 GglObject ggl_obj_f64(double value);
 
 /// Get the f64 represented by an object.
 /// The GglObject must be of type GGL_TYPE_F64.
-GGL_EXPORT CONST
+VISIBILITY(default) CONST
 double ggl_obj_into_f64(GglObject f64);
 
 /// Create buffer object.
-GGL_EXPORT CONST
+VISIBILITY(default) CONST
 GglObject ggl_obj_buf(GglBuffer value);
 
 /// Get the buffer represented by an object.
 /// The GglObject must be of type GGL_TYPE_BUF.
-GGL_EXPORT CONST
+VISIBILITY(default) CONST
 GglBuffer ggl_obj_into_buf(GglObject buf);
 
 /// Create map object.
-GGL_EXPORT CONST
+VISIBILITY(default) CONST
 GglObject ggl_obj_map(GglMap value);
 
 /// Get the map represented by an object.
 /// The GglObject must be of type GGL_TYPE_MAP.
-GGL_EXPORT CONST
+VISIBILITY(default) CONST
 GglMap ggl_obj_into_map(GglObject map);
 
 /// Create list object.
-GGL_EXPORT CONST
+VISIBILITY(default) CONST
 GglObject ggl_obj_list(GglList value);
 
 /// Get the list represented by an object.
 /// The GglObject must be of type GGL_TYPE_LIST.
-GGL_EXPORT CONST
+VISIBILITY(default) CONST
 GglList ggl_obj_into_list(GglObject list);
 
 #endif

--- a/include/ggl/object.h
+++ b/include/ggl/object.h
@@ -75,63 +75,63 @@ typedef struct {
     }
 
 /// Get type of an GglObject
-VISIBILITY(default) CONST
+CONST
 GglObjectType ggl_obj_type(GglObject obj);
 
 #define GGL_OBJ_NULL (GglObject) { 0 }
 
 /// Create bool object.
-VISIBILITY(default) CONST
+CONST
 GglObject ggl_obj_bool(bool value);
 
 /// Get the bool represented by an object.
 /// The GglObject must be of type GGL_TYPE_BOOLEAN.
-VISIBILITY(default) CONST
+CONST
 bool ggl_obj_into_bool(GglObject boolean);
 
 /// Create signed integer object.
-VISIBILITY(default) CONST
+CONST
 GglObject ggl_obj_i64(int64_t value);
 
 /// Get the i64 represented by an object.
 /// The GglObject must be of type GGL_TYPE_I64.
-VISIBILITY(default) CONST
+CONST
 int64_t ggl_obj_into_i64(GglObject i64);
 
 /// Create floating point object.
-VISIBILITY(default) CONST
+CONST
 GglObject ggl_obj_f64(double value);
 
 /// Get the f64 represented by an object.
 /// The GglObject must be of type GGL_TYPE_F64.
-VISIBILITY(default) CONST
+CONST
 double ggl_obj_into_f64(GglObject f64);
 
 /// Create buffer object.
-VISIBILITY(default) CONST
+CONST
 GglObject ggl_obj_buf(GglBuffer value);
 
 /// Get the buffer represented by an object.
 /// The GglObject must be of type GGL_TYPE_BUF.
-VISIBILITY(default) CONST
+CONST
 GglBuffer ggl_obj_into_buf(GglObject buf);
 
 /// Create map object.
-VISIBILITY(default) CONST
+CONST
 GglObject ggl_obj_map(GglMap value);
 
 /// Get the map represented by an object.
 /// The GglObject must be of type GGL_TYPE_MAP.
-VISIBILITY(default) CONST
+CONST
 GglMap ggl_obj_into_map(GglObject map);
 
 /// Create list object.
-VISIBILITY(default) CONST
+CONST
 GglObject ggl_obj_list(GglList value);
 
 /// Get the list represented by an object.
 /// The GglObject must be of type GGL_TYPE_LIST.
-VISIBILITY(default) CONST
+CONST
 GglList ggl_obj_into_list(GglObject list);
 
 #endif

--- a/include/ggl/sdk.h
+++ b/include/ggl/sdk.h
@@ -10,7 +10,7 @@
 /// Initializes the sdk, including starting necessary threads.
 /// Unused portions of sdk may not be initialized.
 /// Exits on error.
-GGL_EXPORT
+VISIBILITY(default)
 void ggl_sdk_init(void);
 
 #endif

--- a/include/ggl/sdk.h
+++ b/include/ggl/sdk.h
@@ -5,12 +5,9 @@
 #ifndef GGL_SDK_H
 #define GGL_SDK_H
 
-#include <ggl/attr.h>
-
 /// Initializes the sdk, including starting necessary threads.
 /// Unused portions of sdk may not be initialized.
 /// Exits on error.
-VISIBILITY(default)
 void ggl_sdk_init(void);
 
 #endif

--- a/priv_include/ggl/alloc.h
+++ b/priv_include/ggl/alloc.h
@@ -13,8 +13,6 @@
 
 /// Allocator vtable.
 typedef struct {
-    ALLOC_SIZE(2)
-    ALLOC_ALIGN(3)
     void *(*const ALLOC)(void *ctx, size_t size, size_t alignment);
     void (*const FREE)(void *ctx, void *ptr);
 } DESIGNATED_INIT GglAllocVtable;
@@ -34,7 +32,7 @@ typedef struct {
 
 /// Allocate memory from an allocator.
 /// Prefer `GGL_ALLOC` or `GGL_ALLOCN`.
-VISIBILITY(hidden) ALLOC_SIZE(2) ALLOC_ALIGN(3)
+VISIBILITY(hidden)
 void *ggl_alloc(GglAlloc alloc, size_t size, size_t alignment);
 
 /// Free memory allocated from an allocator.


### PR DESCRIPTION
Removes -fvisibility=hidden and compile flag for making symbols default/hidden. Making symbols hidden does not help with size, only visibility and avoiding PLT indirection. 

Also removes alloc_size attribute usage since it is broken.