### PR TITLE
Add access back to ggl_arena_alloc

### DIFF
--- a/include/ggl/arena.h
+++ b/include/ggl/arena.h
@@ -42,6 +42,7 @@ static inline GglArena ggl_arena_init(GglBuffer buf) {
     (typeof(type) *) ggl_arena_alloc(arena, (n) * sizeof(type), alignof(type))
 
 /// Allocate `size` bytes with given alignment from an arena.
+ACCESS(read_write, 1)
 void *ggl_arena_alloc(GglArena *arena, size_t size, size_t alignment);
 
 /// Resize ptr's allocation (must be the last allocated ptr).


### PR DESCRIPTION
The access attribute was accidentally removed when removing alloc_align.