### PR TITLE
Various C++ bindings fixes

### DIFF
--- a/cpp/.clang-tidy
+++ b/cpp/.clang-tidy
@@ -5,3 +5,5 @@ CheckOptions:
     value: lower_case
   - key: readability-identifier-naming.StructCase
     value: aNy_CasE
+Checks:
+  - bugprone-multi-level-implicit-pointer-conversion

--- a/cpp/include/ggl/map.hpp
+++ b/cpp/include/ggl/map.hpp
@@ -14,7 +14,7 @@
 #include <iterator>
 #include <span>
 #include <stdexcept>
-#include <string>
+#include <string> // IWYU pragma: keep (std::char_traits)
 #include <string_view>
 #include <type_traits>
 #include <utility>

--- a/cpp/include/ggl/object.hpp
+++ b/cpp/include/ggl/object.hpp
@@ -98,6 +98,7 @@ public:
     }
 
     Object(std::integral auto i64) noexcept
+        requires(!std::is_same_v<bool, std::remove_cv_t<decltype(i64)>>)
         : GglObject { ggl_obj_i64(static_cast<int64_t>(i64)) } {
     }
 
@@ -119,7 +120,7 @@ public:
 
     template <size_t N>
     Object(const char (&arr)[N]) noexcept
-        : Object { std::string_view { arr, N } } {
+        : Object { std::string_view { arr } } {
     }
 
     Object(List list) noexcept

--- a/cpp/samples/object_manipulation/main.cpp
+++ b/cpp/samples/object_manipulation/main.cpp
@@ -1,4 +1,3 @@
-#include <ggl/buffer.hpp>
 #include <ggl/list.hpp>
 #include <ggl/map.hpp>
 #include <ggl/object.hpp>
@@ -21,15 +20,14 @@ int main() {
     std::array list { ggl::Object { "15" },
                       ggl::Object { 24 },
                       ggl::Object { 4.0 } };
-    std::array pairs { ggl::KV { "key", false },
+    std::array pairs { ggl::KV { "key", ggl::Object { false } },
                        ggl::KV { "another key", "Value" },
                        ggl::KV { "key3", "Anything" },
                        ggl::KV { "key4", 25 },
                        ggl::KV { "key5",
                                  ggl::List { list.data(), list.size() } } };
     ggl::Map map { pairs.data(), pairs.size() };
-    ggl::Buffer buffer { "thing" };
-    std::array items { ggl::Object { buffer },
+    std::array items { ggl::Object { "String value" },
                        ggl::Object { map },
                        ggl::Object { 10.0F } };
 

--- a/cpp/samples/object_manipulation/main.cpp
+++ b/cpp/samples/object_manipulation/main.cpp
@@ -8,7 +8,7 @@
 #include <iostream>
 #include <optional>
 #include <span>
-#include <string>
+#include <string> // IWYU pragma: keep (operator<<)
 #include <string_view>
 #include <system_error>
 #include <variant>

--- a/cpp/src/ipc/get_config.cpp
+++ b/cpp/src/ipc/get_config.cpp
@@ -69,7 +69,7 @@ GglError get_config_obj_callback(void *ctx, GglMap result) noexcept {
         return GGL_ERR_PARSE;
     }
 
-    size_t len;
+    size_t len = 0;
     error = ggl_obj_mem_usage(value, &len);
     if (error) {
         return GGL_ERR_INVALID;
@@ -136,7 +136,7 @@ namespace {
             params,
             fn,
             detail::get_config_error_callback,
-            &value
+            value
         );
     }
 

--- a/cpp/src/ipc/update_config.cpp
+++ b/cpp/src/ipc/update_config.cpp
@@ -9,7 +9,7 @@
 #include <ggl/object.hpp>
 #include <chrono>
 #include <ctime>
-#include <ratio>
+#include <ratio> // IWYU pragma: keep (duration uses ratio)
 #include <span>
 #include <system_error>
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
* Fix UB in Client::get_config
* Fix Object selecting int64_t constructor for bool
* Fix Object including null-terminator in Buffer
* Fix likely-spurious uninitialized variable warning
* Reconcile IWYU and clangd include-remover lints
 
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
