### PR TITLE
Write bindgen output to OUT_DIR

### DIFF
--- a/rust/.gitignore
+++ b/rust/.gitignore
@@ -1,5 +1,4 @@
 /target/
-/src/c.rs
 /include/
 /priv_include/
 /csrc/

--- a/rust/build.rs
+++ b/rust/build.rs
@@ -55,14 +55,9 @@ fn main() {
         .allowlist_type("Gg.*")
         .allowlist_type("GgIpc.*")
         .allowlist_var("GG_.*")
-        .raw_line("#![allow(non_upper_case_globals)]")
-        .raw_line("#![allow(non_camel_case_types)]")
-        .raw_line("#![allow(non_snake_case)]")
-        .raw_line("#![allow(dead_code)]")
-        .raw_line("#![allow(clippy::pedantic)]")
         .generate()
         .unwrap()
-        .write_to_file(manifest_dir.join("src/c.rs"))
+        .write_to_file(PathBuf::from(env::var("OUT_DIR").unwrap()).join("c.rs"))
         .unwrap();
 
     let mut src_files = Vec::new();

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -12,7 +12,14 @@
 extern crate std;
 
 mod buffer;
-mod c;
+mod c {
+    #![allow(non_upper_case_globals)]
+    #![allow(non_camel_case_types)]
+    #![allow(non_snake_case)]
+    #![allow(dead_code)]
+    #![allow(clippy::pedantic)]
+    include!(concat!(env!("OUT_DIR"), "/c.rs"));
+}
 mod error;
 mod ipc;
 mod object;


### PR DESCRIPTION
The generated `c.rs` was written into the source tree, which fails on read-only filesystems such as docs.rs. Write to `OUT_DIR` instead and include from there.