### PR TITLE
fix(rust): Fix timespec construction for 32-bit targets (armv7)

### DIFF
--- a/rust/src/ipc.rs
+++ b/rust/src/ipc.rs
@@ -485,9 +485,11 @@ impl Sdk {
                 key_path_to_buf_list(key_path, &mut c_key_path_mem)?;
 
             #[expect(clippy::cast_possible_wrap)]
+            #[allow(clippy::cast_lossless, clippy::needless_update)]
             let timespec = timestamp.map(|d| c::timespec {
-                tv_sec: d.as_secs() as i64,
-                tv_nsec: i64::from(d.subsec_nanos()),
+                tv_sec: d.as_secs() as _,
+                tv_nsec: d.subsec_nanos() as _,
+                ..c::timespec::default()
             });
 
             Result::from(unsafe {


### PR DESCRIPTION
# fix(rust): Fix timespec construction for 32-bit targets (armv7)

## Problem

The Rust crate fails to compile for 32-bit targets with 64-bit `time_t` (e.g., `armv7-unknown-linux-musleabihf`):

```
error[E0063]: missing fields `_bitfield_1` and `_bitfield_align_1` in initializer of `timespec`
   --> src/ipc.rs:488:46
    |
488 |             let timespec = timestamp.map(|d| c::timespec {
    |                                              ^^^^^^^^^^^ missing `_bitfield_1` and `_bitfield_align_1`

error[E0308]: mismatched types
   --> src/ipc.rs:490:26
    |
490 |                 tv_nsec: i64::from(d.subsec_nanos()),
    |                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `i32`, found `i64`
```

## Root Cause

`update_config` in `ipc.rs` constructs `c::timespec` with hardcoded `i64` types. On 64-bit targets, bindgen generates `tv_sec: i64, tv_nsec: i64` — this works. On 32-bit musl targets, `time_t` is still 64-bit but `long` is 32-bit, so bindgen generates `tv_nsec: i32` plus padding bitfields. The hardcoded types and struct literal initialization don't match.

## Fix

Replace struct literal initialization with `Default::default()` + field assignment using `as _`:

```rust
// Before
let timespec = timestamp.map(|d| c::timespec {
    tv_sec: d.as_secs() as i64,
    tv_nsec: i64::from(d.subsec_nanos()),
});

// After
let timespec = timestamp.map(|d| {
    let mut ts = c::timespec::default();
    ts.tv_sec = d.as_secs() as _;
    ts.tv_nsec = d.subsec_nanos() as _;
    ts
});
```

- `default()` zero-initializes all fields including padding/bitfields
- `as _` lets the compiler infer the correct integer type per target

## Testing

Cross-compiled successfully with `cargo zigbuild --release` for all three targets:
- `x86_64-unknown-linux-musl` ✅
- `aarch64-unknown-linux-musl` ✅
- `armv7-unknown-linux-musleabihf` ✅

## Reproduce

```toml
# Cargo.toml
[package]
name = "repro"
version = "0.1.0"
edition = "2024"

[dependencies]
gg_sdk = { version = "1.0", package = "aws-greengrass-component-sdk" }
```

```bash
cargo zigbuild --release --target armv7-unknown-linux-musleabihf
```
