### PR TITLE
Rust build.rs compatibility fixes

### DIFF
--- a/rust/build.rs
+++ b/rust/build.rs
@@ -34,8 +34,11 @@ fn main() {
         c_src_dir = project_root.join("src");
     }
 
+    let target = env::var("TARGET").unwrap();
+
     bindgen::Builder::default()
         .header(manifest_dir.join("wrapper.h").to_str().unwrap())
+        .clang_arg(format!("--target={target}"))
         .clang_arg(format!("-I{}", include_dir.display()))
         .clang_arg(format!("-I{}", priv_include_dir.display()))
         .clang_arg(format!("-I{}", mock_dir.display()))

--- a/rust/build.rs
+++ b/rust/build.rs
@@ -100,10 +100,13 @@ fn main() {
         .define("GG_MODULE", "\"gg-sdk\"")
         .define("GG_LOG_LEVEL", "GG_LOG_DEBUG");
 
+    if env::var("OPT_LEVEL").unwrap() == "z" {
+        build.flag_if_supported("-Oz");
+    }
+
     if env::var("PROFILE").unwrap() == "release" {
-        build.flag("-Oz");
         build.flag("-flto");
-        build.flag("-ffat-lto-objects");
+        build.flag_if_supported("-ffat-lto-objects");
     }
 
     build.compile("gg-sdk");


### PR DESCRIPTION
Adds commits for better cross-compilation support and older GCC support.