### PR TITLE
Release v1.0.3

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,16 @@
+# Release Notes v1.0.3
+
+## Bug Fixes
+
+- Ensure error callback is called when subscription request fails.
+- Send IPC stream terminations to server when subscription is cleaned up by user
+  callback error.
+
+## Rust Improvements
+
+- Enable Rust crate build on older GCC versions.
+- Set bindgen clang target argument for Rust crate cross-compilation.
+
 # Release Notes v1.0.2
 
 ## Bug Fixes

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -13,7 +13,7 @@ dependencies = [
 
 [[package]]
 name = "aws-greengrass-component-sdk"
-version = "1.0.2"
+version = "1.0.3"
 dependencies = [
  "bindgen",
  "cc",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aws-greengrass-component-sdk"
-version = "1.0.2"
+version = "1.0.3"
 edition = "2024"
 license = "Apache-2.0"
 repository = "https://github.com/aws/aws-greengrass-component-sdk"


### PR DESCRIPTION
Bug Fixes:

- Ensure error callback is called when subscription request fails.
- Send IPC stream terminations to server when subscription is cleaned up by user callback error.

Rust Improvements:

- Enable Rust crate build on older GCC versions.
- Set bindgen clang target argument for Rust crate cross-compilation.