### PR TITLE
Release 1.0.4

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,9 @@
+# Release Notes v1.0.4
+
+## Bug Fixes
+
+- Notify Nucleus of cleaned up request when a request times out.
+
 # Release Notes v1.0.3
 
 ## Bug Fixes

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -13,7 +13,7 @@ dependencies = [
 
 [[package]]
 name = "aws-greengrass-component-sdk"
-version = "1.0.3"
+version = "1.0.4"
 dependencies = [
  "bindgen",
  "cc",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aws-greengrass-component-sdk"
-version = "1.0.3"
+version = "1.0.4"
 edition = "2024"
 license = "Apache-2.0"
 repository = "https://github.com/aws/aws-greengrass-component-sdk"


### PR DESCRIPTION
## Bug Fixes

- Notify Nucleus of cleaned up request when a request times out.