### PR TITLE
Add opt-in request tracing for cross-daemon log correlation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -226,9 +226,15 @@ target_include_directories(gg-sdk SYSTEM INTERFACE include)
 
 target_compile_definitions(gg-sdk PRIVATE "GG_MODULE=(\"gg-sdk\")")
 
+option(GG_LOG_TRACE "Enable request tracing in log output" OFF)
+
 string(TOUPPER "${GG_LOG_LEVEL}" log_level)
 set(choose_level "$<IF:$<BOOL:${log_level}>,${log_level},DEBUG>")
 target_compile_definitions(gg-sdk PUBLIC GG_LOG_LEVEL=GG_LOG_${choose_level})
+
+if(GG_LOG_TRACE)
+  target_compile_definitions(gg-sdk PUBLIC GG_TRACE_ENABLED)
+endif()
 
 if(BUILD_TESTING)
   include(unity-test-suite.cmake)
@@ -260,6 +266,12 @@ if(PROJECT_IS_TOP_LEVEL)
         continue()
       endif()
       get_filename_component(test_name ${test_dir} NAME_WLE)
+      # The trace test is a standalone test (its own main(), needs pthread and
+      # _GNU_SOURCE) and only exists when tracing is enabled. It is built by the
+      # dedicated GG_LOG_TRACE-gated trace_test target below, so skip it here.
+      if(test_name STREQUAL "trace")
+        continue()
+      endif()
       file(GLOB_RECURSE TEST_SRCS CONFIGURE_DEPENDS ${test_dir}/*.c)
       if(NOT "${test_dir}/main.c" IN_LIST TEST_SRCS)
         list(APPEND TEST_SRCS test/main_ipc_overrides.c)
@@ -301,4 +313,17 @@ endif()
 
 if(BUILD_CPP)
   add_subdirectory(cpp)
+endif()
+
+if(GG_LOG_TRACE
+   AND BUILD_TESTING
+   AND PROJECT_IS_TOP_LEVEL)
+  include(CTest)
+  add_executable(trace_test test/trace/main.c)
+  target_include_directories(trace_test PRIVATE include priv_include)
+  target_link_libraries(trace_test PRIVATE gg-sdk)
+  target_compile_definitions(trace_test PRIVATE "GG_MODULE=(\"trace_test\")")
+  target_compile_definitions(trace_test PRIVATE _GNU_SOURCE)
+  target_link_libraries(trace_test PRIVATE pthread)
+  add_test(NAME trace_test COMMAND trace_test)
 endif()

--- a/flake.nix
+++ b/flake.nix
@@ -117,14 +117,15 @@
           };
 
         pname = "gg-sdk";
-        package = { stdenv, cmake, ninja, static ? true }:
+        package = { stdenv, cmake, ninja, static ? true, trace ? false }:
           stdenv.mkDerivation {
             name = "gg-sdk";
             src = filteredSrc;
             nativeBuildInputs = [ cmake ninja ];
             cmakeBuildType = "MinSizeRel";
             cmakeFlags = [ "-DENABLE_WERROR=1" ]
-              ++ lib.optional (!static) "-DBUILD_SHARED_LIBS=1";
+              ++ lib.optional (!static) "-DBUILD_SHARED_LIBS=1"
+              ++ lib.optional trace "-DGG_LOG_TRACE=ON";
             hardeningDisable = [ "all" ];
             dontStrip = true;
           };
@@ -180,7 +181,7 @@
           in
           {
             build-clang = pkgs: pkgs.gg-sdk.override
-              { stdenv = llvmStdenv pkgs; };
+              { stdenv = llvmStdenv pkgs; trace = true; };
 
             build-shared = shared-lib;
 
@@ -239,7 +240,7 @@
                 src = filteredTestSrc;
                 nativeBuildInputs = [ git cmake ninja ];
                 cmakeBuildType = "MinSizeRel";
-                cmakeFlags = (fetchContentFlags pkgs) ++ [ "-DBUILD_TESTING=1" "-DBUILD_SAMPLES=0" ];
+                cmakeFlags = (fetchContentFlags pkgs) ++ [ "-DBUILD_TESTING=1" "-DBUILD_SAMPLES=0" "-DGG_LOG_TRACE=ON" ];
                 postBuild = ''
                   ctest --verbose
                 '';

--- a/priv_include/gg/log.h
+++ b/priv_include/gg/log.h
@@ -80,4 +80,24 @@ static inline void gg_log_disabled(const char *format, ...) {
 #define GG_LOGT(...) gg_log_disabled(__VA_ARGS__)
 #endif
 
+#ifdef GG_TRACE_ENABLED
+
+/// Set the trace context for the current thread.
+void gg_log_set_trace(
+    uint16_t trace_id, uint16_t span_id, uint16_t parent_span_id
+);
+
+/// Clear the trace context for the current thread.
+void gg_log_clear_trace(void);
+
+/// Return the current thread's trace_id (0 = no trace active).
+uint16_t gg_log_current_trace_id(void);
+
+/// Copy the current thread's trace context into the provided pointers.
+void gg_log_get_trace(
+    uint16_t *trace_id, uint16_t *span_id, uint16_t *parent_span_id
+);
+
+#endif // GG_TRACE_ENABLED
+
 #endif

--- a/priv_include/gg/trace.h
+++ b/priv_include/gg/trace.h
@@ -1,0 +1,73 @@
+// aws-greengrass-component-sdk - Lightweight AWS IoT Greengrass SDK
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef GG_TRACE_H
+#define GG_TRACE_H
+
+#ifdef GG_TRACE_ENABLED
+
+#include <gg/attr.h>
+#include <gg/eventstream/decode.h>
+#include <gg/eventstream/types.h>
+#include <gg/log.h>
+#include <gg/macro_util.h>
+#include <stdbool.h>
+#include <stddef.h>
+
+/// Start a root trace if none is active on this thread (idempotent).
+/// Generates fresh trace_id and span_id, sets TLS, emits one INFO log line.
+FORMAT(printf, 2, 3)
+void gg_trace_root_begin(const char *kind, const char *fmt, ...);
+
+/// Attach T/S/P trace headers to an outbound EventStream frame.
+/// Returns 3 on success, 0 if no trace active or headers_capacity < 3.
+size_t gg_trace_attach_headers(
+    EventStreamHeader *headers, size_t headers_capacity
+);
+
+/// Extract T/S/P from inbound header iterator and set TLS for the new span.
+/// Returns true if trace context was found and applied; false otherwise.
+bool gg_trace_extract_and_apply(EventStreamHeaderIter headers);
+
+// Internal: cleanup callback for GG_TRACE_SCOPE_GUARD.
+static inline void gg_trace_scope_clear_(const int *guard) {
+    (void) guard;
+    gg_log_clear_trace();
+}
+
+/// Clear the thread trace context automatically when the enclosing scope exits.
+/// Place after gg_trace_root_begin / gg_trace_extract_and_apply so the trace is
+/// cleared on every normal return path (replaces a manual
+/// gg_log_clear_trace()).
+#define GG_TRACE_SCOPE_GUARD() \
+    __attribute__((cleanup(gg_trace_scope_clear_))) const int GG_MACRO_PASTE( \
+        gg_trace_guard_, __LINE__ \
+    ) = 0
+
+/// Begin a root trace and clear it automatically on scope exit.
+/// Forwards all args to gg_trace_root_begin(kind, fmt, ...).
+/// NOTE: declares a scope-guard variable, so it must be used inside a brace
+/// block.
+#define GG_TRACE_ROOT_SCOPE(...) \
+    gg_log_clear_trace(); \
+    gg_trace_root_begin(__VA_ARGS__); \
+    GG_TRACE_SCOPE_GUARD()
+
+/// Inherit trace context from inbound EventStream headers and clear it on scope
+/// exit. NOTE: declares a scope-guard variable, so it must be used inside a
+/// brace block.
+#define GG_TRACE_INHERIT_SCOPE(headers) \
+    gg_log_clear_trace(); \
+    gg_trace_extract_and_apply(headers); \
+    GG_TRACE_SCOPE_GUARD()
+
+#else
+
+#define GG_TRACE_SCOPE_GUARD()
+#define GG_TRACE_ROOT_SCOPE(...)
+#define GG_TRACE_INHERIT_SCOPE(headers)
+
+#endif // GG_TRACE_ENABLED
+
+#endif

--- a/src/log.c
+++ b/src/log.c
@@ -43,6 +43,14 @@ __attribute__((constructor)) static void configure_logging(void) {
     }
 }
 
+#ifdef GG_TRACE_ENABLED
+
+static _Thread_local uint16_t tls_trace_id;
+static _Thread_local uint16_t tls_span_id;
+static _Thread_local uint16_t tls_parent_span_id;
+
+#endif // GG_TRACE_ENABLED
+
 void gg_log(
     uint32_t level,
     const char *file,
@@ -101,7 +109,43 @@ void gg_log(
     {
         GG_MTX_SCOPE_GUARD(&log_mutex);
 
+#ifdef GG_TRACE_ENABLED
+        if (tls_trace_id != 0U) {
+            char parent_buf[5];
+            if (tls_parent_span_id == 0U) {
+                parent_buf[0] = '-';
+                parent_buf[1] = '-';
+                parent_buf[2] = '-';
+                parent_buf[3] = '-';
+                parent_buf[4] = '\0';
+            } else {
+                snprintf(
+                    parent_buf,
+                    sizeof(parent_buf),
+                    "%04X",
+                    (unsigned) tls_parent_span_id
+                );
+            }
+            fprintf(
+                stderr,
+                "%s%c[%s] [%04X:%04X:%s:%s:%d] ",
+                prefix,
+                level_c,
+                tag,
+                (unsigned) tls_trace_id,
+                (unsigned) tls_span_id,
+                parent_buf,
+                file,
+                line
+            );
+        } else {
+            fprintf(
+                stderr, "%s%c[%s] %s:%d: ", prefix, level_c, tag, file, line
+            );
+        }
+#else
         fprintf(stderr, "%s%c[%s] %s:%d: ", prefix, level_c, tag, file, line);
+#endif
 
         va_list args;
         va_start(args, format);
@@ -115,3 +159,33 @@ void gg_log(
 
     errno = saved_errno;
 }
+
+#ifdef GG_TRACE_ENABLED
+
+void gg_log_set_trace(
+    uint16_t trace_id, uint16_t span_id, uint16_t parent_span_id
+) {
+    tls_trace_id = trace_id;
+    tls_span_id = span_id;
+    tls_parent_span_id = parent_span_id;
+}
+
+void gg_log_clear_trace(void) {
+    tls_trace_id = 0;
+    tls_span_id = 0;
+    tls_parent_span_id = 0;
+}
+
+uint16_t gg_log_current_trace_id(void) {
+    return tls_trace_id;
+}
+
+void gg_log_get_trace(
+    uint16_t *trace_id, uint16_t *span_id, uint16_t *parent_span_id
+) {
+    *trace_id = tls_trace_id;
+    *span_id = tls_span_id;
+    *parent_span_id = tls_parent_span_id;
+}
+
+#endif // GG_TRACE_ENABLED

--- a/src/trace.c
+++ b/src/trace.c
@@ -1,0 +1,106 @@
+// aws-greengrass-component-sdk - Lightweight AWS IoT Greengrass SDK
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+#include <gg/trace.h>
+
+#ifdef GG_TRACE_ENABLED
+
+#include <gg/buffer.h>
+#include <gg/error.h>
+#include <gg/eventstream/decode.h>
+#include <gg/eventstream/types.h>
+#include <gg/log.h>
+#include <gg/rand.h>
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <stdio.h>
+
+static uint16_t gen_nonzero_id(void) {
+    uint16_t id;
+    gg_rand_fill((GgBuffer) { .data = (uint8_t *) &id, .len = sizeof(id) });
+    if (id == 0U) {
+        id = 1;
+    }
+    return id;
+}
+
+void gg_trace_root_begin(const char *kind, const char *fmt, ...) {
+    if (gg_log_current_trace_id() != 0U) {
+        return;
+    }
+
+    uint16_t trace_id = gen_nonzero_id();
+    uint16_t span_id = gen_nonzero_id();
+    gg_log_set_trace(trace_id, span_id, 0);
+
+    if (fmt != NULL) {
+        char buf[128] = { 0 };
+        va_list args;
+        va_start(args, fmt);
+        (void) vsnprintf(buf, sizeof(buf), fmt, args);
+        va_end(args);
+        GG_LOGI("trace_start: %s %s", kind, buf);
+    } else {
+        GG_LOGI("trace_start: %s", kind);
+    }
+}
+
+size_t gg_trace_attach_headers(
+    EventStreamHeader *headers, size_t headers_capacity
+) {
+    uint16_t t;
+    uint16_t s;
+    uint16_t p;
+    gg_log_get_trace(&t, &s, &p);
+    if (t == 0U) {
+        return 0;
+    }
+    if (headers_capacity < 3U) {
+        return 0;
+    }
+
+    headers[0] = (EventStreamHeader) {
+        GG_STR("T"), { EVENTSTREAM_INT32, { .int32 = (int32_t) t } }
+    };
+    headers[1] = (EventStreamHeader) {
+        GG_STR("S"), { EVENTSTREAM_INT32, { .int32 = (int32_t) s } }
+    };
+    headers[2] = (EventStreamHeader) {
+        GG_STR("P"), { EVENTSTREAM_INT32, { .int32 = (int32_t) p } }
+    };
+    return 3;
+}
+
+bool gg_trace_extract_and_apply(EventStreamHeaderIter headers) {
+    uint16_t trace_id = 0;
+    uint16_t caller_span = 0;
+    bool found_t = false;
+
+    EventStreamHeaderIter it = headers;
+    EventStreamHeader h;
+    while (eventstream_header_next(&it, &h) == GG_ERR_OK) {
+        if (gg_buffer_eq(h.name, GG_STR("T"))
+            && (h.value.type == EVENTSTREAM_INT32)) {
+            trace_id = (uint16_t) h.value.int32;
+            found_t = true;
+        } else if (gg_buffer_eq(h.name, GG_STR("S"))
+                   && (h.value.type == EVENTSTREAM_INT32)) {
+            caller_span = (uint16_t) h.value.int32;
+        } else {
+            // Not T or S; ignore.
+        }
+    }
+
+    if (!found_t) {
+        return false;
+    }
+
+    uint16_t fresh_span = gen_nonzero_id();
+    gg_log_set_trace(trace_id, fresh_span, caller_span);
+    return true;
+}
+
+#endif // GG_TRACE_ENABLED

--- a/test/trace/main.c
+++ b/test/trace/main.c
@@ -1,0 +1,312 @@
+// aws-greengrass-component-sdk - Lightweight AWS IoT Greengrass SDK
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+#include <assert.h>
+#include <gg/buffer.h>
+#include <gg/error.h>
+#include <gg/eventstream/decode.h>
+#include <gg/eventstream/encode.h>
+#include <gg/eventstream/types.h>
+#include <gg/io.h>
+#include <gg/log.h>
+#include <gg/trace.h>
+#include <pthread.h>
+#include <string.h>
+#include <unistd.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+// === TLS / format tests (existing) ===
+
+// Test a) initial state and set
+static void test_initial_and_set(void) {
+    assert(gg_log_current_trace_id() == 0);
+    gg_log_set_trace(0xA34F, 0x34BD, 0);
+    assert(gg_log_current_trace_id() != 0);
+    assert(gg_log_current_trace_id() == 0xA34F);
+    gg_log_clear_trace();
+    printf("  PASS: test_initial_and_set\n");
+}
+
+// Test b) get returns exact values; clear resets
+static void test_get_and_clear(void) {
+    gg_log_set_trace(0x1234, 0x5678, 0x9ABC);
+    uint16_t t, s, p;
+    gg_log_get_trace(&t, &s, &p);
+    assert(t == 0x1234);
+    assert(s == 0x5678);
+    assert(p == 0x9ABC);
+    gg_log_clear_trace();
+    assert(gg_log_current_trace_id() == 0);
+    gg_log_get_trace(&t, &s, &p);
+    assert(t == 0 && s == 0 && p == 0);
+    printf("  PASS: test_get_and_clear\n");
+}
+
+// Test c) multi-thread isolation
+struct thread_args {
+    uint16_t trace_id;
+    uint16_t span_id;
+    uint16_t parent_span_id;
+    int ok;
+};
+
+static void *thread_fn(void *arg) {
+    struct thread_args *a = (struct thread_args *) arg;
+    gg_log_set_trace(a->trace_id, a->span_id, a->parent_span_id);
+    // Sleep briefly to allow interleaving
+    usleep(50000);
+    uint16_t t, s, p;
+    gg_log_get_trace(&t, &s, &p);
+    a->ok = (t == a->trace_id && s == a->span_id && p == a->parent_span_id);
+    return NULL;
+}
+
+static void test_thread_isolation(void) {
+    struct thread_args a1 = {
+        .trace_id = 0xAAAA, .span_id = 0xBBBB, .parent_span_id = 0xCCCC, .ok = 0
+    };
+    struct thread_args a2 = {
+        .trace_id = 0x1111, .span_id = 0x2222, .parent_span_id = 0x3333, .ok = 0
+    };
+    pthread_t t1, t2;
+    int rc1 = pthread_create(&t1, NULL, thread_fn, &a1);
+    int rc2 = pthread_create(&t2, NULL, thread_fn, &a2);
+    assert(rc1 == 0);
+    assert(rc2 == 0);
+    pthread_join(t1, NULL);
+    pthread_join(t2, NULL);
+    assert(a1.ok);
+    assert(a2.ok);
+    printf("  PASS: test_thread_isolation\n");
+}
+
+// Test d) log prefix format
+static void test_log_prefix_format(void) {
+    char tmppath[] = "/tmp/gg_trace_test_XXXXXX";
+    int fd = mkstemp(tmppath);
+    assert(fd >= 0);
+
+    // Redirect stderr to temp file
+    FILE *old_stderr = stderr;
+    FILE *tmp = fdopen(fd, "w+");
+    assert(tmp != NULL);
+    stderr = tmp;
+
+    // Log with trace active (parent=0 -> "----")
+    gg_log_set_trace(0xA34F, 0x34BD, 0);
+    GG_LOGI("hello traced");
+    fflush(stderr);
+
+    // Read back
+    fseek(tmp, 0, SEEK_SET);
+    char buf[512] = { 0 };
+    size_t n = fread(buf, 1, sizeof(buf) - 1, tmp);
+    (void) n;
+
+    // Assert trace bracket present with ---- parent
+    assert(strstr(buf, "[A34F:34BD:----:") != NULL);
+    assert(strstr(buf, "hello traced") != NULL);
+
+    // Now clear trace and log again
+    gg_log_clear_trace();
+    long pos = ftell(tmp);
+    GG_LOGI("hello untraced");
+    fflush(stderr);
+
+    // Read the new line
+    fseek(tmp, pos, SEEK_SET);
+    char buf2[512] = { 0 };
+    n = fread(buf2, 1, sizeof(buf2) - 1, tmp);
+    (void) n;
+
+    // Untraced line should have no bracket, should have file:line: format
+    assert(strstr(buf2, "[A34F:") == NULL);
+    assert(strstr(buf2, "hello untraced") != NULL);
+
+    // Restore stderr
+    stderr = old_stderr;
+    fclose(tmp);
+    unlink(tmppath);
+    printf("  PASS: test_log_prefix_format\n");
+}
+
+// === Orchestration tests (ported from ggl-trace) ===
+
+static void test_root_begin_generates_nonzero_and_idempotent(void) {
+    gg_log_clear_trace();
+
+    gg_trace_root_begin("test_op", "key=%s", "value");
+
+    uint16_t t, s, p;
+    gg_log_get_trace(&t, &s, &p);
+    assert(t != 0);
+    assert(s != 0);
+    assert(p == 0);
+    assert(gg_log_current_trace_id() == t);
+
+    // Idempotent: second call does not change IDs
+    uint16_t t2, s2, p2;
+    gg_trace_root_begin("other_op", NULL);
+    gg_log_get_trace(&t2, &s2, &p2);
+    assert(t2 == t);
+    assert(s2 == s);
+    assert(p2 == p);
+
+    gg_log_clear_trace();
+    printf("  PASS: root_begin generates non-zero IDs and is idempotent\n");
+}
+
+static void test_attach_headers(void) {
+    EventStreamHeader hdrs[3];
+
+    // No trace active -> returns 0
+    gg_log_clear_trace();
+    size_t n_inactive = gg_trace_attach_headers(hdrs, 3);
+    assert(n_inactive == 0);
+
+    // Set a known trace
+    gg_log_set_trace(0xBEEF, 0xCAFE, 0x1234);
+    size_t n_active = gg_trace_attach_headers(hdrs, 3);
+    assert(n_active == 3);
+
+    assert(gg_buffer_eq(hdrs[0].name, GG_STR("T")));
+    assert(hdrs[0].value.int32 == (int32_t) 0xBEEF);
+    assert(gg_buffer_eq(hdrs[1].name, GG_STR("S")));
+    assert(hdrs[1].value.int32 == (int32_t) 0xCAFE);
+    assert(gg_buffer_eq(hdrs[2].name, GG_STR("P")));
+    assert(hdrs[2].value.int32 == (int32_t) 0x1234);
+
+    // Capacity < 3 -> returns 0
+    size_t n_small = gg_trace_attach_headers(hdrs, 2);
+    assert(n_small == 0);
+
+    gg_log_clear_trace();
+    printf("  PASS: attach_headers correct with/without active trace\n");
+}
+
+/// Encode headers into wire format and decode back to get an iterator.
+/// Returns the decoded EventStreamMessage (caller must keep wire_buf alive).
+static EventStreamMessage encode_decode_headers(
+    EventStreamHeader *headers, size_t count, uint8_t *wire_buf, size_t buf_len
+) {
+    GgBuffer buf = { .data = wire_buf, .len = buf_len };
+    GgError err = eventstream_encode(&buf, headers, count, GG_NULL_READER);
+    assert(err == GG_ERR_OK);
+
+    // Decode: first 12 bytes are the prelude
+    GgBuffer prelude_buf = { .data = wire_buf, .len = 12 };
+    EventStreamPrelude prelude;
+    err = eventstream_decode_prelude(prelude_buf, &prelude);
+    assert(err == GG_ERR_OK);
+
+    GgBuffer data_section = { .data = wire_buf + 12, .len = prelude.data_len };
+    EventStreamMessage msg;
+    err = eventstream_decode(&prelude, data_section, &msg);
+    assert(err == GG_ERR_OK);
+
+    return msg;
+}
+
+static void test_round_trip(void) {
+    gg_log_clear_trace();
+    gg_log_set_trace(0xA34F, 0x34BD, 0);
+
+    EventStreamHeader hdrs[3];
+    size_t n = gg_trace_attach_headers(hdrs, 3);
+    assert(n == 3);
+
+    // Encode to wire and decode back to get an EventStreamHeaderIter
+    uint8_t wire_buf[256];
+    EventStreamMessage msg = encode_decode_headers(hdrs, 3, wire_buf, 256);
+
+    gg_log_clear_trace();
+
+    bool applied = gg_trace_extract_and_apply(msg.headers);
+    assert(applied);
+
+    uint16_t t, s, p;
+    gg_log_get_trace(&t, &s, &p);
+    assert(t == 0xA34F);
+    assert(s != 0);
+    assert(s != 0x34BD); // fresh span, not caller's
+    assert(p == 0x34BD); // parent = caller's span
+
+    gg_log_clear_trace();
+    printf(
+        "  PASS: round-trip preserves trace_id, fresh span, parent=caller\n"
+    );
+}
+
+static void test_extract_no_t_header(void) {
+    // Set a sentinel trace
+    gg_log_set_trace(0x1111, 0x2222, 0x3333);
+
+    // Headers without T — just method and type (like a normal core-bus frame)
+    EventStreamHeader hdrs[2] = {
+        { GG_STR("method"), { EVENTSTREAM_STRING, .string = GG_STR("test") } },
+        { GG_STR("type"), { EVENTSTREAM_INT32, { .int32 = 1 } } },
+    };
+
+    uint8_t wire_buf[256];
+    EventStreamMessage msg = encode_decode_headers(hdrs, 2, wire_buf, 256);
+
+    bool applied = gg_trace_extract_and_apply(msg.headers);
+    assert(!applied);
+
+    // TLS unchanged
+    uint16_t t, s, p;
+    gg_log_get_trace(&t, &s, &p);
+    assert(t == 0x1111);
+    assert(s == 0x2222);
+    assert(p == 0x3333);
+
+    gg_log_clear_trace();
+    printf("  PASS: extract_and_apply returns false without T header\n");
+}
+
+static void test_extract_wrong_type_t_header(void) {
+    // Set a sentinel trace
+    gg_log_set_trace(0x1111, 0x2222, 0x3333);
+
+    // T header with wrong type (STRING instead of INT32)
+    EventStreamHeader hdrs[2] = {
+        { GG_STR("T"), { EVENTSTREAM_STRING, .string = GG_STR("garbage") } },
+        { GG_STR("S"), { EVENTSTREAM_INT32, { .int32 = 0x00FF } } },
+    };
+
+    uint8_t wire_buf[256];
+    EventStreamMessage msg = encode_decode_headers(hdrs, 2, wire_buf, 256);
+
+    bool applied = gg_trace_extract_and_apply(msg.headers);
+    assert(!applied);
+
+    // TLS unchanged (sentinel preserved)
+    uint16_t t, s, p;
+    gg_log_get_trace(&t, &s, &p);
+    assert(t == 0x1111);
+    assert(s == 0x2222);
+    assert(p == 0x3333);
+
+    gg_log_clear_trace();
+    printf(
+        "  PASS: extract_and_apply returns false with wrong-type T header\n"
+    );
+}
+
+int main(void) {
+    printf("trace_test:\n");
+    test_initial_and_set();
+    test_get_and_clear();
+    test_thread_isolation();
+    test_log_prefix_format();
+    test_root_begin_generates_nonzero_and_idempotent();
+    test_attach_headers();
+    test_round_trip();
+    test_extract_no_t_header();
+    test_extract_wrong_type_t_header();
+    printf("ALL PASS\n");
+    return 0;
+}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Add `GG_LOG_TRACE` build flag (default OFF); when on, `gg_log()` prepends a `[trace_id:span_id:parent_span_id:file:line]` bracket so one request can be grepped across daemons. Output is byte-identical when off.
- Add thread-local trace storage and accessors (`gg_log_set_trace`, `gg_log_clear_trace`, `gg_log_current_trace_id`, `gg_log_get_trace`).
- Add `gg/trace.h` + `trace.c` orchestration (`gg_trace_root_begin`, `gg_trace_attach_headers`, `gg_trace_extract_and_apply`) and self-gating scope macros (`GG_TRACE_SCOPE_GUARD`, `GG_TRACE_ROOT_SCOPE`, `GG_TRACE_INHERIT_SCOPE`).
- Add a `test/trace` unit suite (9 cases) and two `GG_LOG_TRACE=ON` CI checks (`build-clang-trace`, `unit-tests-trace`).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
