### PR TITLE
Rename GG_LOG_TRACE build flag to GG_LOG_TRAIL

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -226,14 +226,14 @@ target_include_directories(gg-sdk SYSTEM INTERFACE include)
 
 target_compile_definitions(gg-sdk PRIVATE "GG_MODULE=(\"gg-sdk\")")
 
-option(GG_LOG_TRACE "Enable request tracing in log output" OFF)
+option(GG_LOG_TRAIL "Enable request tracing in log output" OFF)
 
 string(TOUPPER "${GG_LOG_LEVEL}" log_level)
 set(choose_level "$<IF:$<BOOL:${log_level}>,${log_level},DEBUG>")
 target_compile_definitions(gg-sdk PUBLIC GG_LOG_LEVEL=GG_LOG_${choose_level})
 
-if(GG_LOG_TRACE)
-  target_compile_definitions(gg-sdk PUBLIC GG_TRACE_ENABLED)
+if(GG_LOG_TRAIL)
+  target_compile_definitions(gg-sdk PUBLIC GG_LOG_TRAIL_ENABLED)
 endif()
 
 if(BUILD_TESTING)
@@ -268,8 +268,9 @@ if(PROJECT_IS_TOP_LEVEL)
       get_filename_component(test_name ${test_dir} NAME_WLE)
       # The trace test is a standalone test (its own main(), needs pthread and
       # _GNU_SOURCE) and only exists when tracing is enabled. It is built by the
-      # dedicated GG_LOG_TRACE-gated trace_test target below, so skip it here.
-      if(test_name STREQUAL "trace")
+      # dedicated GG_LOG_TRAIL-gated log_trail_test target below, so skip it
+      # here.
+      if(test_name STREQUAL "log-trail")
         continue()
       endif()
       file(GLOB_RECURSE TEST_SRCS CONFIGURE_DEPENDS ${test_dir}/*.c)
@@ -315,15 +316,16 @@ if(BUILD_CPP)
   add_subdirectory(cpp)
 endif()
 
-if(GG_LOG_TRACE
+if(GG_LOG_TRAIL
    AND BUILD_TESTING
    AND PROJECT_IS_TOP_LEVEL)
   include(CTest)
-  add_executable(trace_test test/trace/main.c)
-  target_include_directories(trace_test PRIVATE include priv_include)
-  target_link_libraries(trace_test PRIVATE gg-sdk)
-  target_compile_definitions(trace_test PRIVATE "GG_MODULE=(\"trace_test\")")
-  target_compile_definitions(trace_test PRIVATE _GNU_SOURCE)
-  target_link_libraries(trace_test PRIVATE pthread)
-  add_test(NAME trace_test COMMAND trace_test)
+  add_executable(log_trail_test test/log-trail/main.c)
+  target_include_directories(log_trail_test PRIVATE include priv_include)
+  target_link_libraries(log_trail_test PRIVATE gg-sdk)
+  target_compile_definitions(log_trail_test
+                             PRIVATE "GG_MODULE=(\"log_trail_test\")")
+  target_compile_definitions(log_trail_test PRIVATE _GNU_SOURCE)
+  target_link_libraries(log_trail_test PRIVATE pthread)
+  add_test(NAME log_trail_test COMMAND log_trail_test)
 endif()

--- a/flake.nix
+++ b/flake.nix
@@ -125,7 +125,7 @@
             cmakeBuildType = "MinSizeRel";
             cmakeFlags = [ "-DENABLE_WERROR=1" ]
               ++ lib.optional (!static) "-DBUILD_SHARED_LIBS=1"
-              ++ lib.optional trace "-DGG_LOG_TRACE=ON";
+              ++ lib.optional trace "-DGG_LOG_TRAIL=ON";
             hardeningDisable = [ "all" ];
             dontStrip = true;
           };
@@ -240,7 +240,7 @@
                 src = filteredTestSrc;
                 nativeBuildInputs = [ git cmake ninja ];
                 cmakeBuildType = "MinSizeRel";
-                cmakeFlags = (fetchContentFlags pkgs) ++ [ "-DBUILD_TESTING=1" "-DBUILD_SAMPLES=0" "-DGG_LOG_TRACE=ON" ];
+                cmakeFlags = (fetchContentFlags pkgs) ++ [ "-DBUILD_TESTING=1" "-DBUILD_SAMPLES=0" "-DGG_LOG_TRAIL=ON" ];
                 postBuild = ''
                   ctest --verbose
                 '';

--- a/priv_include/gg/log-trail.h
+++ b/priv_include/gg/log-trail.h
@@ -2,10 +2,10 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-#ifndef GG_TRACE_H
-#define GG_TRACE_H
+#ifndef GG_LOG_TRAIL_H
+#define GG_LOG_TRAIL_H
 
-#ifdef GG_TRACE_ENABLED
+#ifdef GG_LOG_TRAIL_ENABLED
 
 #include <gg/attr.h>
 #include <gg/eventstream/decode.h>
@@ -18,56 +18,56 @@
 /// Start a root trace if none is active on this thread (idempotent).
 /// Generates fresh trace_id and span_id, sets TLS, emits one INFO log line.
 FORMAT(printf, 2, 3)
-void gg_trace_root_begin(const char *kind, const char *fmt, ...);
+void gg_log_trail_root_begin(const char *kind, const char *fmt, ...);
 
 /// Attach T/S/P trace headers to an outbound EventStream frame.
 /// Returns 3 on success, 0 if no trace active or headers_capacity < 3.
-size_t gg_trace_attach_headers(
+size_t gg_log_trail_attach_headers(
     EventStreamHeader *headers, size_t headers_capacity
 );
 
 /// Extract T/S/P from inbound header iterator and set TLS for the new span.
 /// Returns true if trace context was found and applied; false otherwise.
-bool gg_trace_extract_and_apply(EventStreamHeaderIter headers);
+bool gg_log_trail_extract_and_apply(EventStreamHeaderIter headers);
 
-// Internal: cleanup callback for GG_TRACE_SCOPE_GUARD.
-static inline void gg_trace_scope_clear_(const int *guard) {
+// Internal: cleanup callback for GG_LOG_TRAIL_SCOPE_GUARD.
+static inline void gg_log_trail_scope_clear_(const int *guard) {
     (void) guard;
-    gg_log_clear_trace();
+    gg_log_clear_trail();
 }
 
 /// Clear the thread trace context automatically when the enclosing scope exits.
-/// Place after gg_trace_root_begin / gg_trace_extract_and_apply so the trace is
-/// cleared on every normal return path (replaces a manual
-/// gg_log_clear_trace()).
-#define GG_TRACE_SCOPE_GUARD() \
-    __attribute__((cleanup(gg_trace_scope_clear_))) const int GG_MACRO_PASTE( \
-        gg_trace_guard_, __LINE__ \
-    ) = 0
+/// Place after gg_log_trail_root_begin / gg_log_trail_extract_and_apply so the
+/// trace is cleared on every normal return path (replaces a manual
+/// gg_log_clear_trail()).
+#define GG_LOG_TRAIL_SCOPE_GUARD() \
+    __attribute__((cleanup(gg_log_trail_scope_clear_))) const int \
+    GG_MACRO_PASTE(gg_log_trail_guard_, __LINE__) \
+        = 0
 
 /// Begin a root trace and clear it automatically on scope exit.
-/// Forwards all args to gg_trace_root_begin(kind, fmt, ...).
+/// Forwards all args to gg_log_trail_root_begin(kind, fmt, ...).
 /// NOTE: declares a scope-guard variable, so it must be used inside a brace
 /// block.
-#define GG_TRACE_ROOT_SCOPE(...) \
-    gg_log_clear_trace(); \
-    gg_trace_root_begin(__VA_ARGS__); \
-    GG_TRACE_SCOPE_GUARD()
+#define GG_LOG_TRAIL_ROOT_SCOPE(...) \
+    gg_log_clear_trail(); \
+    gg_log_trail_root_begin(__VA_ARGS__); \
+    GG_LOG_TRAIL_SCOPE_GUARD()
 
 /// Inherit trace context from inbound EventStream headers and clear it on scope
 /// exit. NOTE: declares a scope-guard variable, so it must be used inside a
 /// brace block.
-#define GG_TRACE_INHERIT_SCOPE(headers) \
-    gg_log_clear_trace(); \
-    gg_trace_extract_and_apply(headers); \
-    GG_TRACE_SCOPE_GUARD()
+#define GG_LOG_TRAIL_INHERIT_SCOPE(headers) \
+    gg_log_clear_trail(); \
+    gg_log_trail_extract_and_apply(headers); \
+    GG_LOG_TRAIL_SCOPE_GUARD()
 
 #else
 
-#define GG_TRACE_SCOPE_GUARD()
-#define GG_TRACE_ROOT_SCOPE(...)
-#define GG_TRACE_INHERIT_SCOPE(headers)
+#define GG_LOG_TRAIL_SCOPE_GUARD()
+#define GG_LOG_TRAIL_ROOT_SCOPE(...)
+#define GG_LOG_TRAIL_INHERIT_SCOPE(headers)
 
-#endif // GG_TRACE_ENABLED
+#endif // GG_LOG_TRAIL_ENABLED
 
 #endif

--- a/priv_include/gg/log.h
+++ b/priv_include/gg/log.h
@@ -80,24 +80,24 @@ static inline void gg_log_disabled(const char *format, ...) {
 #define GG_LOGT(...) gg_log_disabled(__VA_ARGS__)
 #endif
 
-#ifdef GG_TRACE_ENABLED
+#ifdef GG_LOG_TRAIL_ENABLED
 
 /// Set the trace context for the current thread.
-void gg_log_set_trace(
+void gg_log_set_trail(
     uint16_t trace_id, uint16_t span_id, uint16_t parent_span_id
 );
 
 /// Clear the trace context for the current thread.
-void gg_log_clear_trace(void);
+void gg_log_clear_trail(void);
 
 /// Return the current thread's trace_id (0 = no trace active).
-uint16_t gg_log_current_trace_id(void);
+uint16_t gg_log_current_trail_id(void);
 
 /// Copy the current thread's trace context into the provided pointers.
-void gg_log_get_trace(
+void gg_log_get_trail(
     uint16_t *trace_id, uint16_t *span_id, uint16_t *parent_span_id
 );
 
-#endif // GG_TRACE_ENABLED
+#endif // GG_LOG_TRAIL_ENABLED
 
 #endif

--- a/src/log-trail.c
+++ b/src/log-trail.c
@@ -2,9 +2,9 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-#include <gg/trace.h>
+#include <gg/log-trail.h>
 
-#ifdef GG_TRACE_ENABLED
+#ifdef GG_LOG_TRAIL_ENABLED
 
 #include <gg/buffer.h>
 #include <gg/error.h>
@@ -27,14 +27,14 @@ static uint16_t gen_nonzero_id(void) {
     return id;
 }
 
-void gg_trace_root_begin(const char *kind, const char *fmt, ...) {
-    if (gg_log_current_trace_id() != 0U) {
+void gg_log_trail_root_begin(const char *kind, const char *fmt, ...) {
+    if (gg_log_current_trail_id() != 0U) {
         return;
     }
 
     uint16_t trace_id = gen_nonzero_id();
     uint16_t span_id = gen_nonzero_id();
-    gg_log_set_trace(trace_id, span_id, 0);
+    gg_log_set_trail(trace_id, span_id, 0);
 
     if (fmt != NULL) {
         char buf[128] = { 0 };
@@ -48,13 +48,13 @@ void gg_trace_root_begin(const char *kind, const char *fmt, ...) {
     }
 }
 
-size_t gg_trace_attach_headers(
+size_t gg_log_trail_attach_headers(
     EventStreamHeader *headers, size_t headers_capacity
 ) {
     uint16_t t;
     uint16_t s;
     uint16_t p;
-    gg_log_get_trace(&t, &s, &p);
+    gg_log_get_trail(&t, &s, &p);
     if (t == 0U) {
         return 0;
     }
@@ -74,7 +74,7 @@ size_t gg_trace_attach_headers(
     return 3;
 }
 
-bool gg_trace_extract_and_apply(EventStreamHeaderIter headers) {
+bool gg_log_trail_extract_and_apply(EventStreamHeaderIter headers) {
     uint16_t trace_id = 0;
     uint16_t caller_span = 0;
     bool found_t = false;
@@ -99,8 +99,8 @@ bool gg_trace_extract_and_apply(EventStreamHeaderIter headers) {
     }
 
     uint16_t fresh_span = gen_nonzero_id();
-    gg_log_set_trace(trace_id, fresh_span, caller_span);
+    gg_log_set_trail(trace_id, fresh_span, caller_span);
     return true;
 }
 
-#endif // GG_TRACE_ENABLED
+#endif // GG_LOG_TRAIL_ENABLED

--- a/src/log.c
+++ b/src/log.c
@@ -43,13 +43,13 @@ __attribute__((constructor)) static void configure_logging(void) {
     }
 }
 
-#ifdef GG_TRACE_ENABLED
+#ifdef GG_LOG_TRAIL_ENABLED
 
 static _Thread_local uint16_t tls_trace_id;
 static _Thread_local uint16_t tls_span_id;
 static _Thread_local uint16_t tls_parent_span_id;
 
-#endif // GG_TRACE_ENABLED
+#endif // GG_LOG_TRAIL_ENABLED
 
 void gg_log(
     uint32_t level,
@@ -109,7 +109,7 @@ void gg_log(
     {
         GG_MTX_SCOPE_GUARD(&log_mutex);
 
-#ifdef GG_TRACE_ENABLED
+#ifdef GG_LOG_TRAIL_ENABLED
         if (tls_trace_id != 0U) {
             char parent_buf[5];
             if (tls_parent_span_id == 0U) {
@@ -160,9 +160,9 @@ void gg_log(
     errno = saved_errno;
 }
 
-#ifdef GG_TRACE_ENABLED
+#ifdef GG_LOG_TRAIL_ENABLED
 
-void gg_log_set_trace(
+void gg_log_set_trail(
     uint16_t trace_id, uint16_t span_id, uint16_t parent_span_id
 ) {
     tls_trace_id = trace_id;
@@ -170,17 +170,17 @@ void gg_log_set_trace(
     tls_parent_span_id = parent_span_id;
 }
 
-void gg_log_clear_trace(void) {
+void gg_log_clear_trail(void) {
     tls_trace_id = 0;
     tls_span_id = 0;
     tls_parent_span_id = 0;
 }
 
-uint16_t gg_log_current_trace_id(void) {
+uint16_t gg_log_current_trail_id(void) {
     return tls_trace_id;
 }
 
-void gg_log_get_trace(
+void gg_log_get_trail(
     uint16_t *trace_id, uint16_t *span_id, uint16_t *parent_span_id
 ) {
     *trace_id = tls_trace_id;
@@ -188,4 +188,4 @@ void gg_log_get_trace(
     *parent_span_id = tls_parent_span_id;
 }
 
-#endif // GG_TRACE_ENABLED
+#endif // GG_LOG_TRAIL_ENABLED

--- a/test/log-trail/main.c
+++ b/test/log-trail/main.c
@@ -9,8 +9,8 @@
 #include <gg/eventstream/encode.h>
 #include <gg/eventstream/types.h>
 #include <gg/io.h>
+#include <gg/log-trail.h>
 #include <gg/log.h>
-#include <gg/trace.h>
 #include <pthread.h>
 #include <string.h>
 #include <unistd.h>
@@ -22,25 +22,25 @@
 
 // Test a) initial state and set
 static void test_initial_and_set(void) {
-    assert(gg_log_current_trace_id() == 0);
-    gg_log_set_trace(0xA34F, 0x34BD, 0);
-    assert(gg_log_current_trace_id() != 0);
-    assert(gg_log_current_trace_id() == 0xA34F);
-    gg_log_clear_trace();
+    assert(gg_log_current_trail_id() == 0);
+    gg_log_set_trail(0xA34F, 0x34BD, 0);
+    assert(gg_log_current_trail_id() != 0);
+    assert(gg_log_current_trail_id() == 0xA34F);
+    gg_log_clear_trail();
     printf("  PASS: test_initial_and_set\n");
 }
 
 // Test b) get returns exact values; clear resets
 static void test_get_and_clear(void) {
-    gg_log_set_trace(0x1234, 0x5678, 0x9ABC);
+    gg_log_set_trail(0x1234, 0x5678, 0x9ABC);
     uint16_t t, s, p;
-    gg_log_get_trace(&t, &s, &p);
+    gg_log_get_trail(&t, &s, &p);
     assert(t == 0x1234);
     assert(s == 0x5678);
     assert(p == 0x9ABC);
-    gg_log_clear_trace();
-    assert(gg_log_current_trace_id() == 0);
-    gg_log_get_trace(&t, &s, &p);
+    gg_log_clear_trail();
+    assert(gg_log_current_trail_id() == 0);
+    gg_log_get_trail(&t, &s, &p);
     assert(t == 0 && s == 0 && p == 0);
     printf("  PASS: test_get_and_clear\n");
 }
@@ -55,11 +55,11 @@ struct thread_args {
 
 static void *thread_fn(void *arg) {
     struct thread_args *a = (struct thread_args *) arg;
-    gg_log_set_trace(a->trace_id, a->span_id, a->parent_span_id);
+    gg_log_set_trail(a->trace_id, a->span_id, a->parent_span_id);
     // Sleep briefly to allow interleaving
     usleep(50000);
     uint16_t t, s, p;
-    gg_log_get_trace(&t, &s, &p);
+    gg_log_get_trail(&t, &s, &p);
     a->ok = (t == a->trace_id && s == a->span_id && p == a->parent_span_id);
     return NULL;
 }
@@ -85,7 +85,7 @@ static void test_thread_isolation(void) {
 
 // Test d) log prefix format
 static void test_log_prefix_format(void) {
-    char tmppath[] = "/tmp/gg_trace_test_XXXXXX";
+    char tmppath[] = "/tmp/gg_log_trail_test_XXXXXX";
     int fd = mkstemp(tmppath);
     assert(fd >= 0);
 
@@ -96,7 +96,7 @@ static void test_log_prefix_format(void) {
     stderr = tmp;
 
     // Log with trace active (parent=0 -> "----")
-    gg_log_set_trace(0xA34F, 0x34BD, 0);
+    gg_log_set_trail(0xA34F, 0x34BD, 0);
     GG_LOGI("hello traced");
     fflush(stderr);
 
@@ -111,7 +111,7 @@ static void test_log_prefix_format(void) {
     assert(strstr(buf, "hello traced") != NULL);
 
     // Now clear trace and log again
-    gg_log_clear_trace();
+    gg_log_clear_trail();
     long pos = ftell(tmp);
     GG_LOGI("hello untraced");
     fflush(stderr);
@@ -136,26 +136,26 @@ static void test_log_prefix_format(void) {
 // === Orchestration tests (ported from ggl-trace) ===
 
 static void test_root_begin_generates_nonzero_and_idempotent(void) {
-    gg_log_clear_trace();
+    gg_log_clear_trail();
 
-    gg_trace_root_begin("test_op", "key=%s", "value");
+    gg_log_trail_root_begin("test_op", "key=%s", "value");
 
     uint16_t t, s, p;
-    gg_log_get_trace(&t, &s, &p);
+    gg_log_get_trail(&t, &s, &p);
     assert(t != 0);
     assert(s != 0);
     assert(p == 0);
-    assert(gg_log_current_trace_id() == t);
+    assert(gg_log_current_trail_id() == t);
 
     // Idempotent: second call does not change IDs
     uint16_t t2, s2, p2;
-    gg_trace_root_begin("other_op", NULL);
-    gg_log_get_trace(&t2, &s2, &p2);
+    gg_log_trail_root_begin("other_op", NULL);
+    gg_log_get_trail(&t2, &s2, &p2);
     assert(t2 == t);
     assert(s2 == s);
     assert(p2 == p);
 
-    gg_log_clear_trace();
+    gg_log_clear_trail();
     printf("  PASS: root_begin generates non-zero IDs and is idempotent\n");
 }
 
@@ -163,13 +163,13 @@ static void test_attach_headers(void) {
     EventStreamHeader hdrs[3];
 
     // No trace active -> returns 0
-    gg_log_clear_trace();
-    size_t n_inactive = gg_trace_attach_headers(hdrs, 3);
+    gg_log_clear_trail();
+    size_t n_inactive = gg_log_trail_attach_headers(hdrs, 3);
     assert(n_inactive == 0);
 
     // Set a known trace
-    gg_log_set_trace(0xBEEF, 0xCAFE, 0x1234);
-    size_t n_active = gg_trace_attach_headers(hdrs, 3);
+    gg_log_set_trail(0xBEEF, 0xCAFE, 0x1234);
+    size_t n_active = gg_log_trail_attach_headers(hdrs, 3);
     assert(n_active == 3);
 
     assert(gg_buffer_eq(hdrs[0].name, GG_STR("T")));
@@ -180,10 +180,10 @@ static void test_attach_headers(void) {
     assert(hdrs[2].value.int32 == (int32_t) 0x1234);
 
     // Capacity < 3 -> returns 0
-    size_t n_small = gg_trace_attach_headers(hdrs, 2);
+    size_t n_small = gg_log_trail_attach_headers(hdrs, 2);
     assert(n_small == 0);
 
-    gg_log_clear_trace();
+    gg_log_clear_trail();
     printf("  PASS: attach_headers correct with/without active trace\n");
 }
 
@@ -211,30 +211,30 @@ static EventStreamMessage encode_decode_headers(
 }
 
 static void test_round_trip(void) {
-    gg_log_clear_trace();
-    gg_log_set_trace(0xA34F, 0x34BD, 0);
+    gg_log_clear_trail();
+    gg_log_set_trail(0xA34F, 0x34BD, 0);
 
     EventStreamHeader hdrs[3];
-    size_t n = gg_trace_attach_headers(hdrs, 3);
+    size_t n = gg_log_trail_attach_headers(hdrs, 3);
     assert(n == 3);
 
     // Encode to wire and decode back to get an EventStreamHeaderIter
     uint8_t wire_buf[256];
     EventStreamMessage msg = encode_decode_headers(hdrs, 3, wire_buf, 256);
 
-    gg_log_clear_trace();
+    gg_log_clear_trail();
 
-    bool applied = gg_trace_extract_and_apply(msg.headers);
+    bool applied = gg_log_trail_extract_and_apply(msg.headers);
     assert(applied);
 
     uint16_t t, s, p;
-    gg_log_get_trace(&t, &s, &p);
+    gg_log_get_trail(&t, &s, &p);
     assert(t == 0xA34F);
     assert(s != 0);
     assert(s != 0x34BD); // fresh span, not caller's
     assert(p == 0x34BD); // parent = caller's span
 
-    gg_log_clear_trace();
+    gg_log_clear_trail();
     printf(
         "  PASS: round-trip preserves trace_id, fresh span, parent=caller\n"
     );
@@ -242,7 +242,7 @@ static void test_round_trip(void) {
 
 static void test_extract_no_t_header(void) {
     // Set a sentinel trace
-    gg_log_set_trace(0x1111, 0x2222, 0x3333);
+    gg_log_set_trail(0x1111, 0x2222, 0x3333);
 
     // Headers without T — just method and type (like a normal core-bus frame)
     EventStreamHeader hdrs[2] = {
@@ -253,23 +253,23 @@ static void test_extract_no_t_header(void) {
     uint8_t wire_buf[256];
     EventStreamMessage msg = encode_decode_headers(hdrs, 2, wire_buf, 256);
 
-    bool applied = gg_trace_extract_and_apply(msg.headers);
+    bool applied = gg_log_trail_extract_and_apply(msg.headers);
     assert(!applied);
 
     // TLS unchanged
     uint16_t t, s, p;
-    gg_log_get_trace(&t, &s, &p);
+    gg_log_get_trail(&t, &s, &p);
     assert(t == 0x1111);
     assert(s == 0x2222);
     assert(p == 0x3333);
 
-    gg_log_clear_trace();
+    gg_log_clear_trail();
     printf("  PASS: extract_and_apply returns false without T header\n");
 }
 
 static void test_extract_wrong_type_t_header(void) {
     // Set a sentinel trace
-    gg_log_set_trace(0x1111, 0x2222, 0x3333);
+    gg_log_set_trail(0x1111, 0x2222, 0x3333);
 
     // T header with wrong type (STRING instead of INT32)
     EventStreamHeader hdrs[2] = {
@@ -280,24 +280,24 @@ static void test_extract_wrong_type_t_header(void) {
     uint8_t wire_buf[256];
     EventStreamMessage msg = encode_decode_headers(hdrs, 2, wire_buf, 256);
 
-    bool applied = gg_trace_extract_and_apply(msg.headers);
+    bool applied = gg_log_trail_extract_and_apply(msg.headers);
     assert(!applied);
 
     // TLS unchanged (sentinel preserved)
     uint16_t t, s, p;
-    gg_log_get_trace(&t, &s, &p);
+    gg_log_get_trail(&t, &s, &p);
     assert(t == 0x1111);
     assert(s == 0x2222);
     assert(p == 0x3333);
 
-    gg_log_clear_trace();
+    gg_log_clear_trail();
     printf(
         "  PASS: extract_and_apply returns false with wrong-type T header\n"
     );
 }
 
 int main(void) {
-    printf("trace_test:\n");
+    printf("log_trail_test:\n");
     test_initial_and_set();
     test_get_and_clear();
     test_thread_isolation();


### PR DESCRIPTION
## Description

Rename GG_LOG_TRACE build flag to GG_LOG_TRAIL along with other function and file name to avoid conflict

*By submitting this pull request, I confirm that you can use, modify,
copy, and redistribute this contribution, under the terms of your
choice.*