### PR TITLE
Add GG_LOG_TRAIL_SUBSPAN_SCOPE for intra-daemon sub-spans

### DIFF
--- a/priv_include/gg/log-trail.h
+++ b/priv_include/gg/log-trail.h
@@ -30,6 +30,25 @@ size_t gg_log_trail_attach_headers(
 /// Returns true if trace context was found and applied; false otherwise.
 bool gg_log_trail_extract_and_apply(EventStreamHeaderIter headers);
 
+/// Snapshot of a thread's trail context. Returned by the subspan begin call
+/// and consumed by the scope-exit cleanup to restore the caller's context.
+typedef struct {
+    uint16_t trace_id;
+    uint16_t span_id;
+    uint16_t parent_span_id;
+} GgLogTrailState;
+
+/// Begin a new sub-span within the current trace and log a subspan_start line.
+/// Preserves trace_id, generates a fresh span_id, and makes the caller's
+/// span_id the new parent_span_id. Returns the caller's previous state so the
+/// scope-cleanup can restore it. No-op if no trace is active.
+GgLogTrailState gg_log_trail_subspan_begin(const char *kind);
+
+// Internal: cleanup callback for GG_LOG_TRAIL_SUBSPAN_SCOPE.
+static inline void gg_log_trail_subspan_end_(const GgLogTrailState *saved) {
+    gg_log_set_trail(saved->trace_id, saved->span_id, saved->parent_span_id);
+}
+
 // Internal: cleanup callback for GG_LOG_TRAIL_SCOPE_GUARD.
 static inline void gg_log_trail_scope_clear_(const int *guard) {
     (void) guard;
@@ -62,11 +81,22 @@ static inline void gg_log_trail_scope_clear_(const int *guard) {
     gg_log_trail_extract_and_apply(headers); \
     GG_LOG_TRAIL_SCOPE_GUARD()
 
+/// Begin a sub-span keyed off GG_MODULE and restore the parent context on
+/// scope exit. trace_id is preserved; a fresh span_id is generated; the
+/// previous span_id becomes parent_span_id. No-op if no trace is active.
+/// NOTE: declares a scope-guard variable, so it must be used inside a brace
+/// block.
+#define GG_LOG_TRAIL_SUBSPAN_SCOPE() \
+    __attribute__((cleanup(gg_log_trail_subspan_end_))) const GgLogTrailState \
+    GG_MACRO_PASTE(gg_log_trail_subspan_, __LINE__) \
+        = gg_log_trail_subspan_begin(GG_MODULE)
+
 #else
 
 #define GG_LOG_TRAIL_SCOPE_GUARD()
 #define GG_LOG_TRAIL_ROOT_SCOPE(...)
 #define GG_LOG_TRAIL_INHERIT_SCOPE(headers)
+#define GG_LOG_TRAIL_SUBSPAN_SCOPE()
 
 #endif // GG_LOG_TRAIL_ENABLED
 

--- a/src/log-trail.c
+++ b/src/log-trail.c
@@ -103,4 +103,19 @@ bool gg_log_trail_extract_and_apply(EventStreamHeaderIter headers) {
     return true;
 }
 
+GgLogTrailState gg_log_trail_subspan_begin(const char *kind) {
+    GgLogTrailState saved;
+    gg_log_get_trail(&saved.trace_id, &saved.span_id, &saved.parent_span_id);
+    if (saved.trace_id == 0U) {
+        // No active trace; nothing to open.
+        return saved;
+    }
+    uint16_t new_span_id = gen_nonzero_id();
+    gg_log_set_trail(saved.trace_id, new_span_id, saved.span_id);
+    if (kind != NULL) {
+        GG_LOGD("subspan_start: %s", kind);
+    }
+    return saved;
+}
+
 #endif // GG_LOG_TRAIL_ENABLED

--- a/test/log-trail/main.c
+++ b/test/log-trail/main.c
@@ -296,6 +296,92 @@ static void test_extract_wrong_type_t_header(void) {
     );
 }
 
+// === Subspan tests ===
+
+// Basic subspan: preserves trace_id, generates a fresh span_id, sets caller's
+// span as the new parent_span_id.
+static void test_subspan_basic(void) {
+    gg_log_set_trail(0xAAAA, 0xBBBB, 0xCCCC);
+
+    GgLogTrailState saved = gg_log_trail_subspan_begin("test_kind");
+    // Saved should hold the caller's context.
+    assert(saved.trace_id == 0xAAAA);
+    assert(saved.span_id == 0xBBBB);
+    assert(saved.parent_span_id == 0xCCCC);
+
+    uint16_t t, s, p;
+    gg_log_get_trail(&t, &s, &p);
+    assert(t == 0xAAAA); // trace_id preserved
+    assert(s != 0xBBBB); // fresh span_id
+    assert(s != 0); // and it's non-zero
+    assert(p == 0xBBBB); // caller's span is our parent
+
+    gg_log_trail_subspan_end_(&saved);
+    gg_log_get_trail(&t, &s, &p);
+    assert(t == 0xAAAA);
+    assert(s == 0xBBBB);
+    assert(p == 0xCCCC);
+
+    gg_log_clear_trail();
+    printf("  PASS: subspan preserves trace, fresh span, parent=caller\n");
+}
+
+// Nested subspan: outer sub-span becomes inner's parent, restore unwinds
+// correctly.
+static void test_subspan_nested(void) {
+    gg_log_set_trail(0xAAAA, 0xBBBB, 0xCCCC);
+
+    GgLogTrailState outer = gg_log_trail_subspan_begin("outer");
+    uint16_t t, outer_span, p;
+    gg_log_get_trail(&t, &outer_span, &p);
+    assert(p == 0xBBBB);
+
+    GgLogTrailState inner = gg_log_trail_subspan_begin("inner");
+    uint16_t inner_span;
+    gg_log_get_trail(&t, &inner_span, &p);
+    assert(t == 0xAAAA);
+    assert(inner_span != outer_span);
+    assert(inner_span != 0);
+    assert(p == outer_span); // inner's parent is outer's span
+
+    gg_log_trail_subspan_end_(&inner);
+    // After inner exits, outer's context should be back.
+    uint16_t t2, s2, p2;
+    gg_log_get_trail(&t2, &s2, &p2);
+    assert(t2 == 0xAAAA);
+    assert(s2 == outer_span);
+    assert(p2 == 0xBBBB);
+
+    gg_log_trail_subspan_end_(&outer);
+    gg_log_get_trail(&t2, &s2, &p2);
+    assert(t2 == 0xAAAA);
+    assert(s2 == 0xBBBB);
+    assert(p2 == 0xCCCC);
+
+    gg_log_clear_trail();
+    printf("  PASS: nested subspans, inner parent = outer span\n");
+}
+
+// No-op path: subspan with no active trace leaves TLS at (0,0,0).
+static void test_subspan_no_active_trace(void) {
+    assert(gg_log_current_trail_id() == 0);
+    GgLogTrailState saved = gg_log_trail_subspan_begin("no_trace");
+    assert(saved.trace_id == 0);
+    assert(saved.span_id == 0);
+    assert(saved.parent_span_id == 0);
+
+    uint16_t t, s, p;
+    gg_log_get_trail(&t, &s, &p);
+    assert(t == 0);
+    assert(s == 0);
+    assert(p == 0);
+
+    gg_log_trail_subspan_end_(&saved); // safe restore, still zero
+    gg_log_get_trail(&t, &s, &p);
+    assert(t == 0 && s == 0 && p == 0);
+    printf("  PASS: subspan is no-op when no trace active\n");
+}
+
 int main(void) {
     printf("log_trail_test:\n");
     test_initial_and_set();
@@ -307,6 +393,9 @@ int main(void) {
     test_round_trip();
     test_extract_no_t_header();
     test_extract_wrong_type_t_header();
+    test_subspan_basic();
+    test_subspan_nested();
+    test_subspan_no_active_trace();
     printf("ALL PASS\n");
     return 0;
 }


### PR DESCRIPTION
## Description

Adds `GG_LOG_TRAIL_SUBSPAN_SCOPE()` — a scope-guarded macro that opens a
child span within the current trace and restores the caller's context on
scope exit. Preserves `trace_id`, generates a fresh `span_id`, sets caller's
previous `span_id` as `parent_span_id`, uses `GG_MODULE` as the kind label,
no-op when no trace is active. Complements the existing `_ROOT_SCOPE` and
`_INHERIT_SCOPE`.


_By submitting this pull request, I confirm that you can use, modify, copy, and
redistribute this contribution, under the terms of your choice._