### PR TITLE
Add private get_config variant using GgObjectReceiver

### DIFF
--- a/priv_include/gg/io.h
+++ b/priv_include/gg/io.h
@@ -10,6 +10,8 @@
 #include <gg/attr.h>
 #include <gg/buffer.h>
 #include <gg/error.h>
+#include <gg/object.h>
+#include <gg/types.h>
 #include <stdio.h>
 
 /// Abstraction for streaming data into
@@ -65,5 +67,26 @@ static inline GgError gg_reader_call_exact(GgReader reader, GgBuffer buf) {
 /// Returns a writer that writes into a buffer, consuming used portion
 VISIBILITY(hidden)
 GgWriter gg_buf_writer(GgBuffer *buf);
+
+/// Abstraction for submitting a GgObject into
+typedef struct {
+    GgError (*submit)(void *ctx, GgObject object);
+    void *ctx;
+} GgObjectReceiver;
+
+/// Pass an object to a GgObjectReceiver
+static inline GgError gg_object_receiver_submit(
+    GgObjectReceiver receiver, GgObject object
+) {
+    if (receiver.submit == NULL) {
+        return (gg_obj_type(object) == GG_TYPE_NULL) ? GG_ERR_OK
+                                                     : GG_ERR_FAILURE;
+    }
+
+    return receiver.submit(receiver.ctx, object);
+}
+
+/// Receiver which accepts no object.
+#define GG_NULL_OBJ_RECEIVER (GgObjectReceiver) { 0 }
 
 #endif

--- a/priv_include/gg/ipc/client_priv.h
+++ b/priv_include/gg/ipc/client_priv.h
@@ -9,12 +9,23 @@
 #include <gg/buffer.h>
 #include <gg/error.h>
 #include <gg/eventstream/decode.h>
+#include <gg/io.h>
 #include <gg/object.h>
+#include <gg/types.h>
 
 VISIBILITY(hidden)
 GgError ggipc_connect_with_payload(GgBuffer socket_path, GgObject payload);
 
 VISIBILITY(hidden)
 GgError ggipc_connect_extra_header_handler(EventStreamHeaderIter headers);
+
+/// Get component configuration value, passing the configuration object
+/// to the provided callback function in the receiver, avoiding a copy.
+VISIBILITY(hidden)
+GgError ggipc_get_config_receive(
+    GgBufList key_path,
+    const GgBuffer *component_name,
+    GgObjectReceiver receiver
+);
 
 #endif

--- a/src/ipc/client/get_config.c
+++ b/src/ipc/client/get_config.c
@@ -2,6 +2,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+#include "get_config_common.h"
 #include <gg/arena.h>
 #include <gg/attr.h>
 #include <gg/buffer.h>
@@ -39,7 +40,7 @@ static GgError error_handler(void *ctx, GgBuffer error_code, GgBuffer message) {
 }
 
 NONNULL(3)
-static GgError ggipc_get_config_common(
+GgError ggipc_get_config_common(
     GgBufList key_path,
     const GgBuffer *component_name,
     GgIpcResultCallback *result_callback,
@@ -75,7 +76,7 @@ static GgError ggipc_get_config_common(
     );
 }
 
-static GgError get_resp_value(
+GgError ggipc_get_config_resp_value(
     GgMap resp, GgObject **value, GgBuffer *final_key
 ) {
     GgError ret = gg_map_validate(
@@ -109,7 +110,8 @@ static GgError copy_config_obj(void *ctx, GgMap result) {
     CopyObjectCtx *copy_ctx = ctx;
 
     GgObject *value;
-    GgError ret = get_resp_value(result, &value, copy_ctx->final_key);
+    GgError ret
+        = ggipc_get_config_resp_value(result, &value, copy_ctx->final_key);
     if (ret != GG_ERR_OK) {
         return GG_ERR_INVALID;
     }
@@ -157,7 +159,8 @@ static GgError copy_config_buf(void *ctx, GgMap result) {
     CopyBufferCtx *resp_ctx = ctx;
 
     GgObject *value;
-    GgError ret = get_resp_value(result, &value, resp_ctx->final_key);
+    GgError ret
+        = ggipc_get_config_resp_value(result, &value, resp_ctx->final_key);
     if (ret != GG_ERR_OK) {
         return GG_ERR_INVALID;
     }

--- a/src/ipc/client/get_config_common.h
+++ b/src/ipc/client/get_config_common.h
@@ -1,0 +1,33 @@
+// aws-greengrass-component-sdk - Lightweight AWS IoT Greengrass SDK
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef GG_IPC_CLIENT_GET_CONFIG_COMMON_H
+#define GG_IPC_CLIENT_GET_CONFIG_COMMON_H
+
+#include <gg/attr.h>
+#include <gg/buffer.h>
+#include <gg/error.h>
+#include <gg/ipc/client_raw.h>
+#include <gg/object.h>
+#include <gg/types.h>
+
+/// Shared implementation for GetConfiguration IPC calls.
+/// Sends the request and invokes the result_callback with the parsed response.
+NONNULL(3) VISIBILITY(hidden)
+GgError ggipc_get_config_common(
+    GgBufList key_path,
+    const GgBuffer *component_name,
+    GgIpcResultCallback *result_callback,
+    void *result_ctx
+);
+
+/// Extract the config value from the IPC response map.
+/// If the response contains a single key matching final_key with a non-map
+/// value, returns that value directly (classic behavior).
+VISIBILITY(hidden)
+GgError ggipc_get_config_resp_value(
+    GgMap resp, GgObject **value, GgBuffer *final_key
+);
+
+#endif

--- a/src/ipc/client/get_config_write.c
+++ b/src/ipc/client/get_config_write.c
@@ -1,0 +1,47 @@
+// aws-greengrass-component-sdk - Lightweight AWS IoT Greengrass SDK
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "get_config_common.h"
+#include <gg/buffer.h>
+#include <gg/error.h>
+#include <gg/io.h>
+#include <gg/ipc/client_priv.h>
+#include <gg/json_encode.h>
+#include <gg/log.h>
+#include <gg/object.h>
+#include <gg/types.h>
+
+typedef struct {
+    GgObjectReceiver receiver;
+    GgBuffer *final_key;
+} ForwardConfigCtx;
+
+static GgError forward_config_object(void *ctx, GgMap result) {
+    ForwardConfigCtx *fwd_ctx = ctx;
+
+    GgObject *value;
+    GgError ret
+        = ggipc_get_config_resp_value(result, &value, fwd_ctx->final_key);
+    if (ret != GG_ERR_OK) {
+        return GG_ERR_INVALID;
+    }
+
+    return gg_object_receiver_submit(fwd_ctx->receiver, *value);
+}
+
+GgError ggipc_get_config_receive(
+    GgBufList key_path,
+    const GgBuffer *component_name,
+    GgObjectReceiver receiver
+) {
+    ForwardConfigCtx write_ctx = {
+        .receiver = receiver,
+        .final_key
+        = (key_path.len == 0) ? NULL : &key_path.bufs[key_path.len - 1],
+    };
+
+    return ggipc_get_config_common(
+        key_path, component_name, &forward_config_object, &write_ctx
+    );
+}


### PR DESCRIPTION
*Issue #, if available:*
aws-greengrass/aws-greengrass-lite#1063
Needed for a shared configuration path between core bus and ggipc clients for recipe variable substitution while avoiding introducing a 20 KB buffer inside ggipcd.

*Description of changes:*
* Add GgObjectReceiver to the private interface, an abstraction for forwarding short-lived objects through callback functions.
* Add get_config_write to private interface, which uses the IPC client's static storage for passing the response to a GgObjectReceiver without additional copies.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
